### PR TITLE
Optimize volatile-only fields in JVM

### DIFF
--- a/atomicfu/src/commonTest/kotlin/kotlinx/atomicfu/test/VolatileOnlyTest.kt
+++ b/atomicfu/src/commonTest/kotlin/kotlinx/atomicfu/test/VolatileOnlyTest.kt
@@ -1,0 +1,20 @@
+package kotlinx.atomicfu.test
+
+import kotlinx.atomicfu.*
+import kotlin.test.*
+
+/**
+ * Tests atomic fields that work as replacement to volatiles (only getValue/setValue)
+ */
+class VolatileOnlyTest {
+    private val _ref = atomic<String?>(null)
+    private val _int = atomic(0)
+
+    @Test
+    fun testVolatileOnly() {
+        _ref.value = "OK"
+        assertEquals("OK", _ref.value)
+        _int.value = 42
+        assertEquals(42, _int.value)
+    }
+}

--- a/atomicfu/src/jvmTest/kotlin/kotlinx/atomicfu/test/VolatileOnlyBytecodeTest.kt
+++ b/atomicfu/src/jvmTest/kotlin/kotlinx/atomicfu/test/VolatileOnlyBytecodeTest.kt
@@ -1,0 +1,34 @@
+package kotlinx.atomicfu.test
+
+import org.junit.*
+
+/**
+ * Makes sure that [VolatileOnlyTest] does not have FU/VH usages in bytecode
+ */
+class VolatileOnlyBytecodeTest {
+    private val strings = listOf("FieldUpdater", "VarHandle")
+
+    @Test
+    fun testBytecode() {
+        val javaClass = VolatileOnlyTest::class.java
+        val resourceName = javaClass.name.replace('.', '/') + ".class"
+        val bytes = javaClass.classLoader.getResourceAsStream(resourceName)!!.use { it.readBytes() }
+        for (ss in strings) {
+            val bs = ss.toByteArray()
+            for (i in bytes.indices) {
+                require(!bytes.equalsAt(i, bs)) {
+                    error("Found unexpected string $ss in $resourceName at offset $i")
+                }
+            }
+        }
+    }
+
+    private fun ByteArray.equalsAt(i: Int, bs: ByteArray): Boolean {
+        if (i + bs.size >= size) return false
+        for (k in bs.indices) {
+            if (this[i + k] != bs[k]) return false
+        }
+        return true
+    }
+}
+


### PR DESCRIPTION
Atomic fields that use getValue/setValue are compiled down to the plain
volatile fields without FieldUpdater/VarHandle attached to them, so
that all @Volatile field in the source can be replaced with atomics
without loosing efficiency of the resulting bytecode.

In order to figure this out, method transformer is run in the Phase 2
on analysis in the special mode, so that data flow can be tracked
from fields to their method to see what methods are called on each
fields.