### PR TITLE
Add the original classesDirs to the friend paths of test compilations

### DIFF
--- a/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
+++ b/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
@@ -212,7 +212,9 @@ fun Project.configureMultiplatformPluginTasks() {
                 (tasks.findByName("${target.name}${compilation.name.capitalize()}") as? Test)?.classpath =
                     originalMainClassesDirs + (compilation as KotlinCompilationToRunnableFiles).runtimeDependencyFiles - mainCompilation.output.classesDirs
 
-                compilation.kotlinOptions.freeCompilerArgs += "-Xfriend-paths=${originalMainClassesDirs.asPath}"
+                compilation.compileKotlinTask.doFirst {
+                    compilation.kotlinOptions.freeCompilerArgs += "-Xfriend-paths=${originalMainClassesDirs.asPath}"
+                }
             }
         }
     }

--- a/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
+++ b/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
@@ -211,6 +211,8 @@ fun Project.configureMultiplatformPluginTasks() {
 
                 (tasks.findByName("${target.name}${compilation.name.capitalize()}") as? Test)?.classpath =
                     originalMainClassesDirs + (compilation as KotlinCompilationToRunnableFiles).runtimeDependencyFiles - mainCompilation.output.classesDirs
+
+                compilation.kotlinOptions.freeCompilerArgs += "-Xfriend-paths=${originalMainClassesDirs.asPath}"
             }
         }
     }


### PR DESCRIPTION
The Kotlin Gradle plugin 1.3.60 has changed how friend paths are determined for the test compilations.
Earlier versions used to take the main's compile task destinationDir as the friend paths, but in 1.3.60,
there's a new mechanism that work on compilation level. According to it, the test compilation considers
the main's output.classesDirs as its friend paths.

The atomicfu-gradle-plugin modifies both the main compilation's output.classesDirs
and the test compilation's classpath, so that they point to different locations.
This caused internal visibility issues with Kotlin 1.3.60.

To fix this, add the main's original classesDirs to the test freeCompilerArgs
as -Xfriend-paths to ensure that internals are visible in the main's original
classes.