### PR TITLE
Update README.md's LockFree on JVM links

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,12 +281,13 @@ private inline fun AtomicBoolean.tryAcquire(): Boolean = compareAndSet(false, tr
 
 ### Testing lock-free data structures on JVM
 
-You can optionally test lock-freedomness of lock-free data structures using `LockFreedomTestEnvironment` class.
-See example in [`LockFreeQueueLFTest`](atomicfu/src/test/kotlin/kotlinx/atomicfu/test/LockFreeQueueLFTest.kt).
+You can optionally test lock-freedomness of lock-free data structures using
+[`LockFreedomTestEnvironment`](atomicfu/src/jvmMain/kotlin/kotlinx/atomicfu/LockFreedomTestEnvironment.kt) class.
+See example in [`LockFreeQueueLFTest`](atomicfu/src/jvmTest/kotlin/kotlinx/atomicfu/test/LockFreeQueueLFTest.kt).
 Testing is performed by pausing one (random) thread before or after a random state-update operation and
-making sure that all other threads can still make progress. 
+making sure that all other threads can still make progress.
 
-In order to make those test to actually perform lock-freedomness testing you need to configure an additional 
+In order to make those test to actually perform lock-freedomness testing you need to configure an additional
 execution of tests with the original (non-transformed) classes for Maven:
 
 ```xml


### PR DESCRIPTION
I saw there was lock free stuff ❤️ but sadly the links were broken 😢 thus fix them!

[Current/Before README.md](https://github.com/Kotlin/kotlinx.atomicfu/blob/master/README.md#testing-lock-free-data-structures-on-jvm) links under

[New/After README.md](https://github.com/3ygun/kotlinx.atomicfu/blob/drs-readme-lockfree-links/README.md#testing-lock-free-data-structures-on-jvm) links under