### PR TITLE
Fix the friend paths compiler args separator

### DIFF
--- a/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
+++ b/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
@@ -158,7 +158,7 @@ private fun KotlinCommonOptions.addFriendPaths(friendPathsFileCollection: FileCo
         is KotlinJsOptions -> "-Xfriend-modules"
         else -> return
     }
-    freeCompilerArgs = freeCompilerArgs + "$argName=${friendPathsFileCollection.asPath}"
+    freeCompilerArgs = freeCompilerArgs + "$argName=${friendPathsFileCollection.joinToString(",")}"
 }
 
 fun Project.configureMultiplatformPluginTasks() {


### PR DESCRIPTION
The original implementation assumed the system-dependent path separator, while the Kotlin compiler
actually splits the argument using just commas. This affected only projects which had more than one 
entry in the original classes dirs, such as projects using Kapt (it has an additional output classes directory).

This change, in particular, fixes the issue https://youtrack.jetbrains.com/issue/KT-35942