### PR TITLE
Access modifiers and naming of *RefVolatile classes fixed.

### DIFF
--- a/atomicfu-transformer/src/main/kotlin/kotlinx/atomicfu/transformer/AtomicFUTransformer.kt
+++ b/atomicfu-transformer/src/main/kotlin/kotlinx/atomicfu/transformer/AtomicFUTransformer.kt
@@ -425,12 +425,11 @@ class AtomicFUTransformer(
                     f.accessors.isEmpty() -> ACC_PRIVATE
                     else -> 0
                 }
-                val protection = visibility or when {
+                val protection = ACC_SYNTHETIC or visibility or when {
                     // reference to wrapper class (primitive atomics) or reference to to j.u.c.a.Atomic*Array (atomic array)
-                    f.isStatic && !vh -> ACC_STATIC or ACC_FINAL or ACC_SYNTHETIC
+                    f.isStatic && !vh -> ACC_STATIC or ACC_FINAL
                     // primitive type field
-                    f.isStatic && vh -> ACC_STATIC or ACC_SYNTHETIC
-                    f.hasExternalAccess -> ACC_SYNTHETIC
+                    f.isStatic && vh -> ACC_STATIC
                     else -> 0
                 }
                 val primitiveType = f.getPrimitiveType(vh)

--- a/atomicfu-transformer/src/main/kotlin/kotlinx/atomicfu/transformer/AtomicFUTransformer.kt
+++ b/atomicfu-transformer/src/main/kotlin/kotlinx/atomicfu/transformer/AtomicFUTransformer.kt
@@ -154,7 +154,7 @@ class FieldInfo(
             return if (hasExternalAccess) mangleInternal(fuName) else fuName
         }
 
-    val refVolatileClassName = "${owner.replace('.', '/')}${name.capitalize()}RefVolatile"
+    val refVolatileClassName = "${owner.replace('.', '/')}$${name.capitalize()}RefVolatile"
     val staticRefVolatileField = refVolatileClassName.substringAfterLast("/").decapitalize()
 
     fun getPrimitiveType(vh: Boolean): Type = if (vh) typeInfo.originalType else typeInfo.transformedType
@@ -420,13 +420,17 @@ class AtomicFUTransformer(
             if (fieldType.sort == OBJECT && fieldType.internalName in AFU_CLASSES) {
                 val fieldId = FieldId(className, name, desc)
                 val f = fields[fieldId]!!
-                val protection = when {
+                val visibility = when {
+                    f.hasExternalAccess -> ACC_PUBLIC
+                    f.accessors.isEmpty() -> ACC_PRIVATE
+                    else -> 0
+                }
+                val protection = visibility or when {
                     // reference to wrapper class (primitive atomics) or reference to to j.u.c.a.Atomic*Array (atomic array)
                     f.isStatic && !vh -> ACC_STATIC or ACC_FINAL or ACC_SYNTHETIC
                     // primitive type field
                     f.isStatic && vh -> ACC_STATIC or ACC_SYNTHETIC
-                    f.hasExternalAccess -> ACC_PUBLIC or ACC_SYNTHETIC
-                    f.accessors.isEmpty() -> ACC_PRIVATE
+                    f.hasExternalAccess -> ACC_SYNTHETIC
                     else -> 0
                 }
                 val primitiveType = f.getPrimitiveType(vh)
@@ -1242,9 +1246,14 @@ class AtomicFUTransformer(
 
         // generates a ref class with volatile field of primitive type inside
         private fun generateRefVolatileClass(f: FieldInfo, arg: Type) {
+            val visibility = when {
+                f.hasExternalAccess -> ACC_PUBLIC
+                f.accessors.isEmpty() -> ACC_PRIVATE
+                else -> 0
+            }
             if (analyzePhase2) return // nop
             val cw = ClassWriter(0)
-            cw.visit(V1_6, ACC_PUBLIC or ACC_SYNTHETIC, f.refVolatileClassName, null, "java/lang/Object", null)
+            cw.visit(V1_6, visibility or ACC_SYNTHETIC, f.refVolatileClassName, null, "java/lang/Object", null)
             //creating class constructor
             val cons = cw.visitMethod(ACC_PUBLIC, "<init>", "(${arg.descriptor})V", null, null)
             code(cons) {
@@ -1258,8 +1267,7 @@ class AtomicFUTransformer(
                 visitMaxs(3, 3)
             }
             //declaring volatile field of primitive type
-            val protection = ACC_VOLATILE
-            cw.visitField(protection, f.name, f.getPrimitiveType(vh).descriptor, null, null)
+            cw.visitField(visibility or ACC_VOLATILE, f.name, f.getPrimitiveType(vh).descriptor, null, null)
             val genFile = outputDir / "${f.refVolatileClassName}.class"
             genFile.mkdirsAndWrite(cw.toByteArray())
         }

--- a/atomicfu/build.gradle
+++ b/atomicfu/build.gradle
@@ -255,19 +255,19 @@ task transformedTestBOTH_6(type: Test, dependsOn: [checkJdk16, transformBOTH]) {
     executable = "$System.env.JDK_16/bin/java"
     classpath = files(configurations.jvmTestRuntimeClasspath, classesPostTransformBOTH)
     testClassesDirs = project.files(classesPostTransformBOTH)
-    exclude '**/*LFTest.*', '**/TraceToStringTest.*'
+    exclude '**/*LFTest.*', '**/TraceToStringTest.*', '**/TopLevelGeneratedDeclarationsReflectionTest.*', '**/SyntheticFUFieldsTest.*'
 }
 
 task transformedTestBOTH_current(type: Test, dependsOn: transformBOTH) {
     classpath = files(configurations.jvmTestRuntimeClasspath, classesPostTransformBOTH)
     testClassesDirs = project.files(classesPostTransformBOTH)
-    exclude '**/*LFTest.*', '**/TraceToStringTest.*'
+    exclude '**/*LFTest.*', '**/TraceToStringTest.*', '**/TopLevelGeneratedDeclarationsReflectionTest.*', '**/SyntheticFUFieldsTest.*'
 }
 
 task transformedTestVH(type: Test, dependsOn: transformVH) {
     classpath = files(configurations.jvmTestRuntimeClasspath, classesPostTransformVH)
     testClassesDirs = project.files(classesPostTransformVH)
-    exclude '**/*LFTest.*', '**/TraceToStringTest.*'
+    exclude '**/*LFTest.*', '**/TraceToStringTest.*', '**/TopLevelGeneratedDeclarationsReflectionTest.*', '**/SyntheticFUFieldsTest.*'
 }
 
 transformedTestVH.onlyIf {
@@ -290,7 +290,7 @@ tasks.withType(Test) {
 }
 
 jvmTest {
-    exclude "**/AtomicfuBytecodeTest*" // run it only for transformed code
+    exclude "**/AtomicfuBytecodeTest*", '**/TopLevelGeneratedDeclarationsReflectionTest.*', '**/SyntheticFUFieldsTest.*' // run them only for transformed code
 }
 
 jvmTest.dependsOn jvmTestAll

--- a/atomicfu/src/commonTest/kotlin/bytecode_test/NoAccessPrivateTopLevelReflectionTest.kt
+++ b/atomicfu/src/commonTest/kotlin/bytecode_test/NoAccessPrivateTopLevelReflectionTest.kt
@@ -1,0 +1,8 @@
+@file:JvmName("NoAccessPrivateTopLevel")
+
+package bytecode_test
+
+import kotlinx.atomicfu.*
+import kotlin.jvm.JvmName
+
+private val a = atomic(1) // no accessors

--- a/atomicfu/src/commonTest/kotlin/bytecode_test/PackagePrivateTopLevelReflectionTest.kt
+++ b/atomicfu/src/commonTest/kotlin/bytecode_test/PackagePrivateTopLevelReflectionTest.kt
@@ -1,0 +1,8 @@
+@file:JvmName("PackagePrivateTopLevel")
+
+package bytecode_test
+
+import kotlinx.atomicfu.*
+import kotlin.jvm.JvmName
+
+internal val d = atomic(0) // accessed from the same package PublicTopLevel.class

--- a/atomicfu/src/commonTest/kotlin/bytecode_test/PrivateFieldAccessFromInnerClassReflectonTest.kt
+++ b/atomicfu/src/commonTest/kotlin/bytecode_test/PrivateFieldAccessFromInnerClassReflectonTest.kt
@@ -1,0 +1,13 @@
+package bytecode_test
+
+import kotlinx.atomicfu.atomic
+
+class PrivateFieldAccessFromInnerClassReflectonTest {
+    private val state = atomic(0)
+
+    inner class InnerClass {
+        fun m() {
+            state.compareAndSet(0, 77)
+        }
+    }
+}

--- a/atomicfu/src/commonTest/kotlin/bytecode_test/PrivateTopLevelReflectionTest.kt
+++ b/atomicfu/src/commonTest/kotlin/bytecode_test/PrivateTopLevelReflectionTest.kt
@@ -1,0 +1,14 @@
+@file:JvmName("PrivateTopLevel")
+
+package bytecode_test
+
+import kotlinx.atomicfu.atomic
+import kotlin.jvm.JvmName
+
+private val b = atomic(2)
+
+class PrivateTopLevelReflectionTest {
+    fun update() {
+        b.compareAndSet(0, 42)
+    }
+}

--- a/atomicfu/src/commonTest/kotlin/bytecode_test/PublicTopLevelReflectionTest.kt
+++ b/atomicfu/src/commonTest/kotlin/bytecode_test/PublicTopLevelReflectionTest.kt
@@ -1,0 +1,14 @@
+@file:JvmName("PublicTopLevel")
+
+package bytecode_test
+
+import kotlinx.atomicfu.*
+import kotlin.jvm.JvmName
+
+internal val c = atomic(0)
+
+class PublicTopLevelReflectionTest {
+    fun update() {
+        d.lazySet(56)
+    }
+}

--- a/atomicfu/src/commonTest/kotlin/internal_test1/B.kt
+++ b/atomicfu/src/commonTest/kotlin/internal_test1/B.kt
@@ -4,7 +4,10 @@
 
 package internal_test1
 
+import bytecode_test.c
 import kotlinx.atomicfu.test.A
+import kotlinx.atomicfu.test.internalTopLevelField
+import kotlinx.atomicfu.test.publicTopLevelField
 import kotlin.test.*
 
 class B {
@@ -23,6 +26,15 @@ class B {
         assertEquals(6, a.intArr[2].value)
         check(a.refArr[3].compareAndSet(null, "OK"))
         assertEquals("OK", a.refArr[3].value)
+    }
+
+    @Test
+    fun testInternalTopLevel() {
+        internalTopLevelField.lazySet(55)
+        check(internalTopLevelField.value == 55)
+        check(publicTopLevelField.compareAndSet(0, 66))
+        check(publicTopLevelField.value == 66)
+        check(c.getAndSet(145) == 0)
     }
 }
 

--- a/atomicfu/src/commonTest/kotlin/kotlinx/atomicfu/test/TopLevelTest.kt
+++ b/atomicfu/src/commonTest/kotlin/kotlinx/atomicfu/test/TopLevelTest.kt
@@ -21,6 +21,9 @@ private val anyRefArr = AtomicArray<Any>(10)
 
 private val stringAtomicNullArr = atomicArrayOfNulls<String>(10)
 
+internal val internalTopLevelField = atomic(0)
+public val publicTopLevelField = atomic(0)
+
 class TopLevelPrimitiveTest {
     @Test
     fun testTopLevelInt() {

--- a/atomicfu/src/jvmTest/kotlin/kotlinx/atomicfu/test/MetadataReflectionTest.kt
+++ b/atomicfu/src/jvmTest/kotlin/kotlinx/atomicfu/test/MetadataReflectionTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.*
 /**
  * Make sure metadata is intact after transformation.
  */
-class ReflectionTest {
+class MetadataReflectionTest {
     @Test
     fun testReflection() {
         val f =

--- a/atomicfu/src/jvmTest/kotlin/kotlinx/atomicfu/test/ReflectionTestBase.kt
+++ b/atomicfu/src/jvmTest/kotlin/kotlinx/atomicfu/test/ReflectionTestBase.kt
@@ -7,6 +7,11 @@ public open class ReflectionTestBase {
     fun checkDeclarations(javaClass: Class<*>, expect: List<FieldDesc>) =
             assertEquals(expect.joinToString(";"), getClassDeclarations(javaClass))
 
+    fun checkClassModifiers(javaClass: Class<*>, modifiers: Int, isSynthetic: Boolean) {
+        assertEquals(isSynthetic, javaClass.isSynthetic)
+        assertEquals(Modifier.toString(modifiers), Modifier.toString(javaClass.modifiers))
+    }
+
     private fun getClassDeclarations(javaClass: Class<*>) =
             javaClass.declaredFields.joinToString(separator = ";") {
                 "${Modifier.toString(it.modifiers)} ${if (it.isSynthetic) "synthetic " else ""}${it.type.name} ${it.name}"

--- a/atomicfu/src/jvmTest/kotlin/kotlinx/atomicfu/test/ReflectionTestBase.kt
+++ b/atomicfu/src/jvmTest/kotlin/kotlinx/atomicfu/test/ReflectionTestBase.kt
@@ -1,0 +1,18 @@
+package kotlinx.atomicfu.test
+
+import java.lang.reflect.Modifier
+import kotlin.test.assertEquals
+
+public open class ReflectionTestBase {
+    fun checkDeclarations(javaClass: Class<*>, expect: List<FieldDesc>) =
+            assertEquals(expect.joinToString(";"), getClassDeclarations(javaClass))
+
+    private fun getClassDeclarations(javaClass: Class<*>) =
+            javaClass.declaredFields.joinToString(separator = ";") {
+                "${Modifier.toString(it.modifiers)} ${if (it.isSynthetic) "synthetic " else ""}${it.type.name} ${it.name}"
+            }
+
+    data class FieldDesc(val modifiers: Int, val isSynthetic: Boolean, val typeName: String, val name: String) {
+        override fun toString() = "${Modifier.toString(modifiers)} ${if (isSynthetic) "synthetic " else ""}$typeName $name"
+    }
+}

--- a/atomicfu/src/jvmTest/kotlin/kotlinx/atomicfu/test/SyntheticFUFieldsTest.kt
+++ b/atomicfu/src/jvmTest/kotlin/kotlinx/atomicfu/test/SyntheticFUFieldsTest.kt
@@ -1,0 +1,21 @@
+package kotlinx.atomicfu.test
+
+import bytecode_test.PrivateFieldAccessFromInnerClassReflectonTest
+import java.lang.reflect.Modifier.*
+import kotlin.test.Test
+
+private const val AFU_TYPE = "java.util.concurrent.atomic.AtomicIntegerFieldUpdater"
+
+/**
+ * Checks that generated FU and VH field updaters are marked as synthetic
+ */
+class SyntheticFUFieldsTest : ReflectionTestBase() {
+    @Test
+    fun testPrivateFieldAccessFromInnerClass() {
+        checkDeclarations(PrivateFieldAccessFromInnerClassReflectonTest::class.java, listOf(
+                FieldDesc(VOLATILE, true, "int", "state"),
+                FieldDesc(STATIC or FINAL, true, AFU_TYPE, "state\$FU")
+            )
+        )
+    }
+}

--- a/atomicfu/src/jvmTest/kotlin/kotlinx/atomicfu/test/TopLevelGeneratedDeclarationsReflectionTest.kt
+++ b/atomicfu/src/jvmTest/kotlin/kotlinx/atomicfu/test/TopLevelGeneratedDeclarationsReflectionTest.kt
@@ -22,6 +22,8 @@ class TopLevelGeneratedDeclarationsReflectionTest : ReflectionTestBase() {
                 FieldDesc(PRIVATE or STATIC or FINAL, true, "$BYTECODE_PACKAGE.NoAccessPrivateTopLevel\$A$REF_VOLATILE", "noAccessPrivateTopLevel\$A$REF_VOLATILE")
             )
         )
+        val refVolatileClass = Class.forName("$BYTECODE_PACKAGE.NoAccessPrivateTopLevel\$A$REF_VOLATILE")
+        checkClassModifiers(refVolatileClass, 0, true)
     }
 
     /**
@@ -36,6 +38,7 @@ class TopLevelGeneratedDeclarationsReflectionTest : ReflectionTestBase() {
             )
         )
         val refVolatileClass = Class.forName("$BYTECODE_PACKAGE.PrivateTopLevel\$B$REF_VOLATILE")
+        checkClassModifiers(refVolatileClass, 0, true)
         checkDeclarations(refVolatileClass, listOf(
                 FieldDesc(VOLATILE, false, "int", "b")
             )
@@ -54,6 +57,7 @@ class TopLevelGeneratedDeclarationsReflectionTest : ReflectionTestBase() {
             )
         )
         val refVolatileClass = Class.forName("$BYTECODE_PACKAGE.PublicTopLevel\$C$REF_VOLATILE")
+        checkClassModifiers(refVolatileClass, PUBLIC, true)
         checkDeclarations(refVolatileClass, listOf(
                 FieldDesc(PUBLIC or VOLATILE, false, "int", "c\$internal")
             )
@@ -72,6 +76,7 @@ class TopLevelGeneratedDeclarationsReflectionTest : ReflectionTestBase() {
         )
         )
         val refVolatileClass = Class.forName("$BYTECODE_PACKAGE.PackagePrivateTopLevel\$D$REF_VOLATILE")
+        checkClassModifiers(refVolatileClass, 0, true)
         checkDeclarations(refVolatileClass, listOf(
                 FieldDesc(VOLATILE, false, "int", "d")
             )

--- a/atomicfu/src/jvmTest/kotlin/kotlinx/atomicfu/test/TopLevelGeneratedDeclarationsReflectionTest.kt
+++ b/atomicfu/src/jvmTest/kotlin/kotlinx/atomicfu/test/TopLevelGeneratedDeclarationsReflectionTest.kt
@@ -1,0 +1,80 @@
+package kotlinx.atomicfu.test
+
+import kotlin.test.Test
+import java.lang.reflect.Modifier.*
+
+private const val REF_VOLATILE = "RefVolatile"
+private const val BYTECODE_PACKAGE = "bytecode_test"
+private const val AFU_TYPE = "java.util.concurrent.atomic.AtomicIntegerFieldUpdater"
+
+/**
+ * Checks access modifiers, name and type for generated declarations.
+ */
+class TopLevelGeneratedDeclarationsReflectionTest : ReflectionTestBase() {
+
+    /**
+     * Test [bytecode_test.NoAccessPrivateTopLevel]
+     */
+    @Test
+    fun testNoAccessPrivateTopLevel() {
+        val javaClass = Class.forName("$BYTECODE_PACKAGE.NoAccessPrivateTopLevel")
+        checkDeclarations(javaClass, listOf(
+                FieldDesc(PRIVATE or STATIC or FINAL, true, "$BYTECODE_PACKAGE.NoAccessPrivateTopLevel\$A$REF_VOLATILE", "noAccessPrivateTopLevel\$A$REF_VOLATILE")
+            )
+        )
+    }
+
+    /**
+     * Test [bytecode_test.PrivateTopLevel]
+     */
+    @Test
+    fun testPrivateTopLevel() {
+        val javaClass = Class.forName("$BYTECODE_PACKAGE.PrivateTopLevel")
+        checkDeclarations(javaClass, listOf(
+                FieldDesc(STATIC or FINAL, true, "$BYTECODE_PACKAGE.PrivateTopLevel\$B$REF_VOLATILE", "privateTopLevel\$B$REF_VOLATILE"),
+                FieldDesc(STATIC or FINAL, true, AFU_TYPE, "b\$FU")
+            )
+        )
+        val refVolatileClass = Class.forName("$BYTECODE_PACKAGE.PrivateTopLevel\$B$REF_VOLATILE")
+        checkDeclarations(refVolatileClass, listOf(
+                FieldDesc(VOLATILE, false, "int", "b")
+            )
+        )
+    }
+
+    /**
+     * Test [bytecode_test.PublicTopLevel]
+     */
+    @Test
+    fun testPublicTopLevelReflectionTest() {
+        val javaClass = Class.forName("$BYTECODE_PACKAGE.PublicTopLevel")
+        checkDeclarations(javaClass, listOf(
+                FieldDesc(PUBLIC or STATIC or FINAL, true, "$BYTECODE_PACKAGE.PublicTopLevel\$C$REF_VOLATILE", "publicTopLevel\$C$REF_VOLATILE"),
+                FieldDesc(PUBLIC or STATIC or FINAL, true, AFU_TYPE, "c\$FU\$internal")
+            )
+        )
+        val refVolatileClass = Class.forName("$BYTECODE_PACKAGE.PublicTopLevel\$C$REF_VOLATILE")
+        checkDeclarations(refVolatileClass, listOf(
+                FieldDesc(PUBLIC or VOLATILE, false, "int", "c\$internal")
+            )
+        )
+    }
+
+    /**
+     * Test [bytecode_test.PackagePrivateTopLevel]
+     */
+    @Test
+    fun testPackagePrivateTopLevelReflectionTest() {
+        val javaClass = Class.forName("$BYTECODE_PACKAGE.PackagePrivateTopLevel")
+        checkDeclarations(javaClass, listOf(
+                FieldDesc(STATIC or FINAL, true, "$BYTECODE_PACKAGE.PackagePrivateTopLevel\$D$REF_VOLATILE", "packagePrivateTopLevel\$D$REF_VOLATILE"),
+                FieldDesc(STATIC or FINAL, true, AFU_TYPE, "d\$FU")
+        )
+        )
+        val refVolatileClass = Class.forName("$BYTECODE_PACKAGE.PackagePrivateTopLevel\$D$REF_VOLATILE")
+        checkDeclarations(refVolatileClass, listOf(
+                FieldDesc(VOLATILE, false, "int", "d")
+            )
+        )
+    }
+}


### PR DESCRIPTION
Access modifiers fixed for: 

- `*RefVolatile` classes
- volatile primitive type fields inside `*RefVolatle` classes
- synthetic `FU` and `*RefVolatile` fields