### PR TITLE
Fixed storing top-level atomics to local variables.

### DIFF
--- a/atomicfu-transformer/src/main/kotlin/kotlinx/atomicfu/transformer/AtomicFUTransformerJS.kt
+++ b/atomicfu-transformer/src/main/kotlin/kotlinx/atomicfu/transformer/AtomicFUTransformerJS.kt
@@ -22,7 +22,7 @@ private const val TRACE_FORMAT = "TraceFormat"
 private const val TRACE_FORMAT_CONSTRUCTOR = "atomicfu\\\$$TRACE_FORMAT\\\$"
 private const val TRACE_FORMAT_FORMAT = "atomicfu\\\$TraceFormat\\\$format\\\$"
 
-private const val RECEIVER = "\$receiver"
+private const val RECEIVER = """(\$(receiver)(_\d+)?)"""
 private const val SCOPE = "scope"
 private const val FACTORY = "factory"
 private const val REQUIRE = "require"
@@ -316,7 +316,7 @@ class AtomicFUTransformerJS(
                         node.setLeftAndRight(targetNode, clearProperety)
                     }
                     // other cases with $receiver.kotlinx$atomicfu$value in inline functions
-                    else if (node.target.toSource() == RECEIVER) {
+                    else if (node.target.toSource().matches(Regex(RECEIVER))) {
                         val rr = ReceiverResolver()
                         node.enclosingFunction.visit(rr)
                         rr.receiver?.let { node.target = it }
@@ -404,7 +404,7 @@ class AtomicFUTransformerJS(
         var receiver: AstNode? = null
         override fun visit(node: AstNode): Boolean {
             if (node is VariableInitializer) {
-                if (node.target.toSource() == RECEIVER) {
+                if (node.target.toSource().matches(Regex(RECEIVER))) {
                     receiver = node.initializer
                     return false
                 }
@@ -420,7 +420,7 @@ class AtomicFUTransformerJS(
                 if (node.target is PropertyGet) {
                     val funcName = (node.target as PropertyGet).property
                     var field = (node.target as PropertyGet).target
-                    if (field.toSource() == RECEIVER) {
+                    if (field.toSource().matches(Regex(RECEIVER))) {
                         val rr = ReceiverResolver()
                         node.enclosingFunction.visit(rr)
                         if (rr.receiver != null) {

--- a/atomicfu/src/commonTest/kotlin/kotlinx/atomicfu/test/TopLevelStoredToLocalVariableTest.kt
+++ b/atomicfu/src/commonTest/kotlin/kotlinx/atomicfu/test/TopLevelStoredToLocalVariableTest.kt
@@ -1,0 +1,51 @@
+package kotlinx.atomicfu.test
+
+import kotlinx.atomicfu.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private val top = atomic(0)
+private val topArr = AtomicIntArray(5)
+
+class TopLevelStoredToLocalVariableTest {
+
+    @Test
+    fun testTopLevelArrayElementUpdate() {
+        topArr[3].update { 55 }
+        assertEquals(55, topArr[3].getAndUpdate { 66 })
+        assertEquals(77, topArr[3].updateAndGet { 77 })
+        topArr[3].loop {  value ->
+            if (value == 77) topArr[3].compareAndSet(value, 66)
+            assertEquals(66, topArr[3].value)
+            return
+        }
+    }
+
+    @Test
+    fun testTopLevelUpdate() {
+        top.update { 5 }
+        assertEquals(5, top.getAndUpdate { 66 })
+        assertEquals(77, top.updateAndGet { 77 })
+        top.loop { value ->
+            assertEquals(77, value)
+            if (value == 77) top.compareAndSet(value, 66)
+            assertEquals(66, top.value)
+            return
+        }
+    }
+
+    @Test
+    fun testObjectFieldUpdate() {
+        Example.update()
+        assertEquals("test !", Example.x)
+    }
+}
+
+object Example {
+    private val _x = atomic("test")
+    val x get() = _x.value
+
+    fun update() {
+        _x.getAndUpdate { "$it !" }
+    }
+}


### PR DESCRIPTION
For a static field stored to local: in the transformed bytecode the local variable is removed and load instructions are replaced with `getstatic` insn of the corresponding field.  

\+ small fix in the JS transformer to match the name-format of generated local variables `$receiver_i`

Fixes #118