### PR TITLE
Add build parameter to build atomicfu with JVM IR compiler

### DIFF
--- a/atomicfu-gradle-plugin/build.gradle
+++ b/atomicfu-gradle-plugin/build.gradle
@@ -5,7 +5,11 @@
 apply plugin: 'kotlin'
 apply plugin: 'java-gradle-plugin'
 
-apply from: rootProject.file('gradle/compile-options.gradle')
+if (rootProject.ext.jvm_ir_enabled) {
+    kotlin.target.compilations.all {
+        kotlinOptions.useIR = true
+    }
+}
 
 // Gradle plugin must be compiled targeting the same Kotlin version as used by Gradle
 kotlin.sourceSets.all {

--- a/atomicfu-gradle-plugin/src/test/resources/projects/jvm-simple/build.gradle
+++ b/atomicfu-gradle-plugin/src/test/resources/projects/jvm-simple/build.gradle
@@ -5,6 +5,11 @@
 apply plugin: 'kotlinx-atomicfu'
 apply plugin: 'kotlin'
 
+// This flag is enabled to be able using JVM IR compiled dependencies (when build is ran with -Penable_jvm_ir)
+kotlin.target.compilations.all {
+    kotlinOptions.freeCompilerArgs += '-Xallow-jvm-ir-dependencies'
+}
+
 dependencies {
     compileOnly atomicfuJvm
     testRuntime atomicfuJvm

--- a/atomicfu-gradle-plugin/src/test/resources/projects/mpp-simple/build.gradle
+++ b/atomicfu-gradle-plugin/src/test/resources/projects/mpp-simple/build.gradle
@@ -6,7 +6,12 @@ apply plugin: 'kotlinx-atomicfu'
 apply plugin: 'kotlin-multiplatform'
 
 kotlin {
-    jvm()
+    // This flag is enabled to be able using JVM IR compiled dependencies (when build is ran with -Penable_jvm_ir)
+    jvm() {
+        compilations.all {
+            kotlinOptions.freeCompilerArgs += '-Xallow-jvm-ir-dependencies'
+        }
+    }
     js()
 
     sourceSets {

--- a/atomicfu/build.gradle
+++ b/atomicfu/build.gradle
@@ -29,26 +29,9 @@ kotlin {
         nodejs()
     }
 
-    targets {
-        // JVM -- always
-        fromPreset(presets.jvm, 'jvm')
+    // JVM -- always
+    jvm()
 
-        if (project.ext.ideaActive) {
-            addNative(fromPreset(project.ext.ideaPreset, 'native'))
-        } else {
-            addTarget(presets.linuxX64)
-            addTarget(presets.iosArm64)
-            addTarget(presets.iosArm32)
-            addTarget(presets.iosX64)
-            addTarget(presets.macosX64)
-            addTarget(presets.mingwX64)
-            addTarget(presets.tvosArm64)
-            addTarget(presets.tvosX64)
-            addTarget(presets.watchosArm32)
-            addTarget(presets.watchosArm64)
-            addTarget(presets.watchosX86)
-        }
-    }
     sourceSets {
         commonMain {
             dependencies {
@@ -84,43 +67,69 @@ kotlin {
                 implementation "junit:junit:$junit_version"
             }
         }
-        nativeMain { dependsOn commonMain }
-
-        nativeTest {}
-
-        if (!project.ext.ideaActive) {
-            configure(nativeMainSets) {
-                dependsOn nativeMain
-            }
-
-            configure(nativeTestSets) {
-                dependsOn nativeTest
-            }
-        }
-    }
-
-    configure(nativeCompilations) {
-        cinterops {
-            interop {
-                defFile 'src/nativeInterop/cinterop/interop.def'
-            }
-        }
     }
 }
 
-// Hack for publishing as HMPP: pack the cinterop klib as a source set:
-if (!project.ext.ideaActive) {
-    kotlin.sourceSets {
-        nativeInterop
-        nativeMain.dependsOn(nativeInterop)
+// configure native targets only if they're not disabled
+if (rootProject.ext.native_targets_enabled) {
+    kotlin {
+        targets {
+            if (project.ext.ideaActive) {
+                addNative(fromPreset(project.ext.ideaPreset, 'native'))
+            } else {
+                addTarget(presets.linuxX64)
+                addTarget(presets.iosArm64)
+                addTarget(presets.iosArm32)
+                addTarget(presets.iosX64)
+                addTarget(presets.macosX64)
+                addTarget(presets.mingwX64)
+                addTarget(presets.tvosArm64)
+                addTarget(presets.tvosX64)
+                addTarget(presets.watchosArm32)
+                addTarget(presets.watchosArm64)
+                addTarget(presets.watchosX86)
+            }
+        }
+
+        sourceSets {
+            nativeMain { dependsOn commonMain }
+
+            nativeTest {}
+
+            if (!project.ext.ideaActive) {
+                configure(nativeMainSets) {
+                    dependsOn nativeMain
+                }
+
+                configure(nativeTestSets) {
+                    dependsOn nativeTest
+                }
+            }
+        }
+
+        configure(nativeCompilations) {
+            cinterops {
+                interop {
+                    defFile 'src/nativeInterop/cinterop/interop.def'
+                }
+            }
+        }
     }
 
-    apply from: "$rootDir/gradle/interop-as-source-set-klib.gradle"
+    // Hack for publishing as HMPP: pack the cinterop klib as a source set:
+    if (!project.ext.ideaActive) {
+        kotlin.sourceSets {
+            nativeInterop
+            nativeMain.dependsOn(nativeInterop)
+        }
 
-    registerInteropAsSourceSetOutput(
-            kotlin.linuxX64().compilations["main"].cinterops["interop"],
-            kotlin.sourceSets["nativeInterop"]
-    )
+        apply from: "$rootDir/gradle/interop-as-source-set-klib.gradle"
+
+        registerInteropAsSourceSetOutput(
+                kotlin.linuxX64().compilations["main"].cinterops["interop"],
+                kotlin.sourceSets["nativeInterop"]
+        )
+    }
 }
 
 configurations {
@@ -129,7 +138,7 @@ configurations {
 
 apply from: rootProject.file('gradle/compile-options.gradle')
 
-ext.configureKotlin()
+ext.configureKotlin(true)
 
 dependencies {
     transformer project(":atomicfu-transformer")

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ buildscript {
             maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
         }
     }
+    // These two flags are enabled in train builds for JVM IR compiler testing
+    ext.jvm_ir_enabled = rootProject.properties['enable_jvm_ir'] != null
+    ext.native_targets_enabled = rootProject.properties['disable_native_targets'] == null
 
     repositories {
         jcenter()

--- a/gradle/compile-options.gradle
+++ b/gradle/compile-options.gradle
@@ -3,7 +3,20 @@
  * Copyright 2017-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-ext.configureKotlin = {
+ext.configureKotlin = { isMultiplatform ->
+    if (rootProject.ext.jvm_ir_enabled) {
+        println "Using JVM IR compiler for project $project.name"
+        if (isMultiplatform) {
+            kotlin.jvm().compilations.all {
+                kotlinOptions.useIR = true
+            }
+        } else {
+            kotlin.target.compilations.all {
+                kotlinOptions.useIR = true
+            }
+        }
+    }
+
     kotlin.sourceSets.all {
         languageSettings {
             apiVersion = "1.4"


### PR DESCRIPTION
To be used in specific kotlinx-train CI configuration. It's needed for faster adoption of JVM IR compiler.