### PR TITLE
Make transformer catch and report all error types

### DIFF
--- a/atomicfu-transformer/src/main/kotlin/kotlinx/atomicfu/transformer/AtomicFUTransformer.kt
+++ b/atomicfu-transformer/src/main/kotlin/kotlinx/atomicfu/transformer/AtomicFUTransformer.kt
@@ -266,7 +266,7 @@ class AtomicFUTransformer(
         val cv = TransformerCV(cw, vh, analyzePhase2 = false)
         try {
             ClassReader(ByteArrayInputStream(bytes)).accept(cv, SKIP_FRAMES)
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             error("Failed to transform: $e", cv.sourceInfo)
             e.printStackTrace(System.out)
             if (lastError == null) lastError = e


### PR DESCRIPTION
Currently, the transformer only catches exceptions while errors like `ClassNotFoundError` are not handled properly. This leads to a poor diagnostic because it's not possible to narrow down what file wasn't processed and why. 
