### PR TITLE
Removing reference to TraceBase class from JS

### DIFF
--- a/atomicfu-transformer/src/main/kotlin/kotlinx/atomicfu/transformer/AtomicFUTransformerJS.kt
+++ b/atomicfu-transformer/src/main/kotlin/kotlinx/atomicfu/transformer/AtomicFUTransformerJS.kt
@@ -16,6 +16,7 @@ private const val ATOMIC_ARRAY_CONSTRUCTOR = """Atomic(Ref|Int|Long|Boolean)Arra
 private const val MANGLED_VALUE_PROP = "kotlinx\$atomicfu\$value"
 
 private const val TRACE_CONSTRUCTOR = "atomicfu\\\$Trace\\\$"
+private const val TRACE_BASE_CLASS = "atomicfu\\\$TraceBase\\\$"
 private const val TRACE_APPEND = "atomicfu\\\$Trace\\\$append\\\$"
 private const val TRACE_NAMED = "atomicfu\\\$Trace\\\$named\\\$"
 private const val TRACE_FORMAT = "TraceFormat"
@@ -221,7 +222,7 @@ class AtomicFUTransformerJS(
                             } else if (initializer.matches(Regex(kotlinxAtomicfuModuleName(TRACE_CONSTRUCTOR)))) {
                                 traceConstructors.add(varInit.target.toSource())
                                 node.replaceChild(stmt, EmptyLine())
-                            } else if (initializer.matches(Regex(kotlinxAtomicfuModuleName("""($LOCKS|$TRACE_FORMAT_CONSTRUCTOR|$TRACE_NAMED)""")))) {
+                            } else if (initializer.matches(Regex(kotlinxAtomicfuModuleName("""($LOCKS|$TRACE_FORMAT_CONSTRUCTOR|$TRACE_BASE_CLASS|$TRACE_NAMED)""")))) {
                                 node.replaceChild(stmt, EmptyLine())
                             }
                         }

--- a/atomicfu/src/commonMain/kotlin/kotlinx/atomicfu/Trace.common.kt
+++ b/atomicfu/src/commonMain/kotlin/kotlinx/atomicfu/Trace.common.kt
@@ -59,6 +59,7 @@ public expect fun TraceBase.named(name: String): TraceBase
  */
 public expect val traceFormatDefault: TraceFormat
 
+@JsName("atomicfu\$TraceBase\$")
 public open class TraceBase internal constructor() {
     @JsName("atomicfu\$Trace\$append\$")
     @PublishedApi


### PR DESCRIPTION
JS transformer is fixed to remove the reference to `kotlinx.atomicfu.TraceBase` class