### PR TITLE
Binary compatibility

### DIFF
--- a/atomicfu/src/commonMain/kotlin/kotlinx/atomicfu/AtomicFU.common.kt
+++ b/atomicfu/src/commonMain/kotlin/kotlinx/atomicfu/AtomicFU.common.kt
@@ -12,66 +12,94 @@ import kotlinx.atomicfu.TraceBase.None
 import kotlin.reflect.KProperty
 
 /**
+ * Creates atomic reference with a given [initial] value and a [trace] object to trace modifications of the value.
+ *
+ * It can only be used to initialize a private or internal read-only property, like this:
+ *
+ * ```
+ * private val f = atomic<Type>(initial, trace)
+ * ```
+ */
+public expect fun <T> atomic(initial: T, trace: TraceBase = None): AtomicRef<T>
+
+// Binary compatibility with IR, should be removed with Kotlin 1.5 release
+/**
  * Creates atomic reference with a given [initial] value.
  *
- * It can only be used in initialize of private read-only property, like this:
+ * It can only be used to initialize a private or internal read-only property, like this:
  *
  * ```
  * private val f = atomic<Type>(initial)
  * ```
  */
-public expect fun <T> atomic(initial: T, trace: TraceBase = None): AtomicRef<T>
-
-/**
- * Binary compatibility with IR, should be removed with Kotlin 1.5 release
- */
 public expect fun <T> atomic(initial: T): AtomicRef<T>
 
 /**
+ * Creates atomic [Int] with a given [initial] value and a [trace] object to trace modifications of the value.
+ *
+ * It can only be used to initialize a private or internal read-only property, like this:
+ *
+ * ```
+ * private val f = atomic(initialInt, trace)
+ * ```
+ */
+public expect fun atomic(initial: Int, trace: TraceBase = None): AtomicInt
+
+// Binary compatibility with IR, should be removed with Kotlin 1.5 release
+/**
  * Creates atomic [Int] with a given [initial] value.
  *
- * It can only be used in initialize of private read-only property, like this:
+ * It can only be used to initialize a private or internal read-only property, like this:
  *
  * ```
  * private val f = atomic(initialInt)
  * ```
  */
-public expect fun atomic(initial: Int, trace: TraceBase = None): AtomicInt
-
-/**
- * Binary compatibility with IR, should be removed with Kotlin 1.5 release
- */
 public expect fun atomic(initial: Int): AtomicInt
 
 /**
+ * Creates atomic [Long] with a given [initial] value and a [trace] object to trace modifications of the value.
+ *
+ * It can only be used to initialize a private or internal read-only property, like this:
+ *
+ * ```
+ * private val f = atomic(initialLong, trace)
+ * ```
+ */
+public expect fun atomic(initial: Long, trace: TraceBase = None): AtomicLong
+
+// Binary compatibility with IR, should be removed with Kotlin 1.5 release
+/**
  * Creates atomic [Long] with a given [initial] value.
  *
- * It can only be used in initialize of private read-only property, like this:
+ * It can only be used to initialize a private or internal read-only property, like this:
  *
  * ```
  * private val f = atomic(initialLong)
  * ```
  */
-public expect fun atomic(initial: Long, trace: TraceBase = None): AtomicLong
-
-/**
- * Binary compatibility with IR, should be removed with Kotlin 1.5 release
- */
 public expect fun atomic(initial: Long): AtomicLong
 
 /**
- * Creates atomic [Boolean] with a given [initial] value.
+ * Creates atomic [Boolean] with a given [initial] value and a [trace] object to trace modifications of the value.
  *
- * It can only be used in initialize of private read-only property, like this:
+ * It can only be used to initialize a private or internal read-only property, like this:
  *
  * ```
- * private val f = atomic(initialBoolean)
+ * private val f = atomic(initialBoolean, trace)
  * ```
  */
 public expect fun atomic(initial: Boolean, trace: TraceBase = None): AtomicBoolean
 
+// Binary compatibility with IR, should be removed with Kotlin 1.5 release
 /**
- * Binary compatibility with IR, should be removed with Kotlin 1.5 release
+ * Creates atomic [Boolean] with a given [initial] value.
+ *
+ * It can only be used to initialize a private or internal read-only property, like this:
+ *
+ * ```
+ * private val f = atomic(initialBoolean)
+ * ```
  */
 public expect fun atomic(initial: Boolean): AtomicBoolean
 

--- a/atomicfu/src/commonMain/kotlin/kotlinx/atomicfu/AtomicFU.common.kt
+++ b/atomicfu/src/commonMain/kotlin/kotlinx/atomicfu/AtomicFU.common.kt
@@ -12,7 +12,7 @@ import kotlinx.atomicfu.TraceBase.None
 import kotlin.reflect.KProperty
 
 /**
- * Creates atomic reference with a given [initial] value and a [trace] object to trace modifications of the value.
+ * Creates atomic reference with a given [initial] value and a [trace] object to [trace modifications][Trace] of the value.
  *
  * It can only be used to initialize a private or internal read-only property, like this:
  *
@@ -23,6 +23,7 @@ import kotlin.reflect.KProperty
 public expect fun <T> atomic(initial: T, trace: TraceBase = None): AtomicRef<T>
 
 // Binary compatibility with IR, should be removed with Kotlin 1.5 release
+
 /**
  * Creates atomic reference with a given [initial] value.
  *
@@ -35,7 +36,7 @@ public expect fun <T> atomic(initial: T, trace: TraceBase = None): AtomicRef<T>
 public expect fun <T> atomic(initial: T): AtomicRef<T>
 
 /**
- * Creates atomic [Int] with a given [initial] value and a [trace] object to trace modifications of the value.
+ * Creates atomic [Int] with a given [initial] value and a [trace] object to [trace modifications][Trace] of the value.
  *
  * It can only be used to initialize a private or internal read-only property, like this:
  *
@@ -46,6 +47,7 @@ public expect fun <T> atomic(initial: T): AtomicRef<T>
 public expect fun atomic(initial: Int, trace: TraceBase = None): AtomicInt
 
 // Binary compatibility with IR, should be removed with Kotlin 1.5 release
+
 /**
  * Creates atomic [Int] with a given [initial] value.
  *
@@ -58,7 +60,7 @@ public expect fun atomic(initial: Int, trace: TraceBase = None): AtomicInt
 public expect fun atomic(initial: Int): AtomicInt
 
 /**
- * Creates atomic [Long] with a given [initial] value and a [trace] object to trace modifications of the value.
+ * Creates atomic [Long] with a given [initial] value and a [trace] object to [trace modifications][Trace] of the value.
  *
  * It can only be used to initialize a private or internal read-only property, like this:
  *
@@ -69,6 +71,7 @@ public expect fun atomic(initial: Int): AtomicInt
 public expect fun atomic(initial: Long, trace: TraceBase = None): AtomicLong
 
 // Binary compatibility with IR, should be removed with Kotlin 1.5 release
+
 /**
  * Creates atomic [Long] with a given [initial] value.
  *
@@ -81,7 +84,7 @@ public expect fun atomic(initial: Long, trace: TraceBase = None): AtomicLong
 public expect fun atomic(initial: Long): AtomicLong
 
 /**
- * Creates atomic [Boolean] with a given [initial] value and a [trace] object to trace modifications of the value.
+ * Creates atomic [Boolean] with a given [initial] value and a [trace] object to [trace modifications][Trace] of the value.
  *
  * It can only be used to initialize a private or internal read-only property, like this:
  *
@@ -92,6 +95,7 @@ public expect fun atomic(initial: Long): AtomicLong
 public expect fun atomic(initial: Boolean, trace: TraceBase = None): AtomicBoolean
 
 // Binary compatibility with IR, should be removed with Kotlin 1.5 release
+
 /**
  * Creates atomic [Boolean] with a given [initial] value.
  *

--- a/atomicfu/src/commonMain/kotlin/kotlinx/atomicfu/AtomicFU.common.kt
+++ b/atomicfu/src/commonMain/kotlin/kotlinx/atomicfu/AtomicFU.common.kt
@@ -10,7 +10,6 @@ import kotlin.js.JsName
 import kotlin.internal.InlineOnly
 import kotlinx.atomicfu.TraceBase.None
 import kotlin.reflect.KProperty
-import kotlin.reflect.KProperty0
 
 /**
  * Creates atomic reference with a given [initial] value.
@@ -23,7 +22,9 @@ import kotlin.reflect.KProperty0
  */
 public expect fun <T> atomic(initial: T, trace: TraceBase = None): AtomicRef<T>
 
-// Binary compatibility
+/**
+ * Binary compatibility with IR, should be removed with Kotlin 1.5 release
+ */
 public expect fun <T> atomic(initial: T): AtomicRef<T>
 
 /**
@@ -37,7 +38,9 @@ public expect fun <T> atomic(initial: T): AtomicRef<T>
  */
 public expect fun atomic(initial: Int, trace: TraceBase = None): AtomicInt
 
-// Binary compatibility
+/**
+ * Binary compatibility with IR, should be removed with Kotlin 1.5 release
+ */
 public expect fun atomic(initial: Int): AtomicInt
 
 /**
@@ -51,7 +54,9 @@ public expect fun atomic(initial: Int): AtomicInt
  */
 public expect fun atomic(initial: Long, trace: TraceBase = None): AtomicLong
 
-// Binary compatibility
+/**
+ * Binary compatibility with IR, should be removed with Kotlin 1.5 release
+ */
 public expect fun atomic(initial: Long): AtomicLong
 
 /**
@@ -65,7 +70,9 @@ public expect fun atomic(initial: Long): AtomicLong
  */
 public expect fun atomic(initial: Boolean, trace: TraceBase = None): AtomicBoolean
 
-// Binary compatibility
+/**
+ * Binary compatibility with IR, should be removed with Kotlin 1.5 release
+ */
 public expect fun atomic(initial: Boolean): AtomicBoolean
 
 /**

--- a/atomicfu/src/commonMain/kotlin/kotlinx/atomicfu/AtomicFU.common.kt
+++ b/atomicfu/src/commonMain/kotlin/kotlinx/atomicfu/AtomicFU.common.kt
@@ -23,6 +23,9 @@ import kotlin.reflect.KProperty0
  */
 public expect fun <T> atomic(initial: T, trace: TraceBase = None): AtomicRef<T>
 
+// Binary compatibility
+public expect fun <T> atomic(initial: T): AtomicRef<T>
+
 /**
  * Creates atomic [Int] with a given [initial] value.
  *
@@ -33,6 +36,9 @@ public expect fun <T> atomic(initial: T, trace: TraceBase = None): AtomicRef<T>
  * ```
  */
 public expect fun atomic(initial: Int, trace: TraceBase = None): AtomicInt
+
+// Binary compatibility
+public expect fun atomic(initial: Int): AtomicInt
 
 /**
  * Creates atomic [Long] with a given [initial] value.
@@ -45,6 +51,9 @@ public expect fun atomic(initial: Int, trace: TraceBase = None): AtomicInt
  */
 public expect fun atomic(initial: Long, trace: TraceBase = None): AtomicLong
 
+// Binary compatibility
+public expect fun atomic(initial: Long): AtomicLong
+
 /**
  * Creates atomic [Boolean] with a given [initial] value.
  *
@@ -55,6 +64,9 @@ public expect fun atomic(initial: Long, trace: TraceBase = None): AtomicLong
  * ```
  */
 public expect fun atomic(initial: Boolean, trace: TraceBase = None): AtomicBoolean
+
+// Binary compatibility
+public expect fun atomic(initial: Boolean): AtomicBoolean
 
 /**
  * Creates array of AtomicRef<T> of specified size, where each element is initialised with null value

--- a/atomicfu/src/commonMain/kotlin/kotlinx/atomicfu/Trace.common.kt
+++ b/atomicfu/src/commonMain/kotlin/kotlinx/atomicfu/Trace.common.kt
@@ -52,7 +52,7 @@ public expect fun Trace(size: Int = 32, format: TraceFormat = traceFormatDefault
 public expect fun TraceBase.named(name: String): TraceBase
 
 /**
- * The default trade string formatter.
+ * The default trace string formatter.
  *
  * On JVM when `kotlinx.atomicfu.trace.thread` system property is set, then the default format
  * also includes thread name for each operation.

--- a/atomicfu/src/jsMain/kotlin/kotlinx/atomicfu/AtomicFU.kt
+++ b/atomicfu/src/jsMain/kotlin/kotlinx/atomicfu/AtomicFU.kt
@@ -7,19 +7,27 @@
 package kotlinx.atomicfu
 
 import kotlin.reflect.KProperty
-import kotlin.reflect.KProperty0
+import kotlinx.atomicfu.TraceBase.None
 
 @JsName("atomic\$ref\$")
 public actual fun <T> atomic(initial: T, trace: TraceBase): AtomicRef<T> = AtomicRef<T>(initial)
 
+public actual inline fun <T> atomic(initial: T): AtomicRef<T> = atomic(initial, None)
+
 @JsName("atomic\$int\$")
 public actual fun atomic(initial: Int, trace: TraceBase): AtomicInt = AtomicInt(initial)
+
+public actual inline fun atomic(initial: Int): AtomicInt = atomic(initial, None)
 
 @JsName("atomic\$long\$")
 public actual fun atomic(initial: Long, trace: TraceBase): AtomicLong = AtomicLong(initial)
 
+public actual inline fun atomic(initial: Long): AtomicLong = atomic(initial, None)
+
 @JsName("atomic\$boolean\$")
 public actual fun atomic(initial: Boolean, trace: TraceBase): AtomicBoolean = AtomicBoolean(initial)
+
+public actual inline fun atomic(initial: Boolean): AtomicBoolean = atomic(initial, None)
 
 // ==================================== AtomicRef ====================================
 

--- a/atomicfu/src/jvmMain/kotlin/kotlinx/atomicfu/AtomicFU.kt
+++ b/atomicfu/src/jvmMain/kotlin/kotlinx/atomicfu/AtomicFU.kt
@@ -11,7 +11,7 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater
 import java.util.concurrent.atomic.AtomicLongFieldUpdater
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater
 import kotlin.reflect.KProperty
-import kotlin.reflect.KProperty0
+import kotlinx.atomicfu.TraceBase.None
 
 /**
  * Creates atomic reference with a given [initial] value.
@@ -24,6 +24,8 @@ import kotlin.reflect.KProperty0
  */
 public actual fun <T> atomic(initial: T, trace: TraceBase): AtomicRef<T> = AtomicRef<T>(initial, trace)
 
+public actual fun <T> atomic(initial: T): AtomicRef<T> = atomic(initial, None)
+
 /**
  * Creates atomic [Int] with a given [initial] value.
  *
@@ -34,6 +36,8 @@ public actual fun <T> atomic(initial: T, trace: TraceBase): AtomicRef<T> = Atomi
  * ```
  */
 public actual fun atomic(initial: Int, trace: TraceBase): AtomicInt = AtomicInt(initial, trace)
+
+public actual fun atomic(initial: Int): AtomicInt = atomic(initial, None)
 
 /**
  * Creates atomic [Long] with a given [initial] value.
@@ -46,6 +50,8 @@ public actual fun atomic(initial: Int, trace: TraceBase): AtomicInt = AtomicInt(
  */
 public actual fun atomic(initial: Long, trace: TraceBase): AtomicLong = AtomicLong(initial, trace)
 
+public actual fun atomic(initial: Long): AtomicLong = atomic(initial, None)
+
 /**
  * Creates atomic [Boolean] with a given [initial] value.
  *
@@ -56,6 +62,8 @@ public actual fun atomic(initial: Long, trace: TraceBase): AtomicLong = AtomicLo
  * ```
  */
 public actual fun atomic(initial: Boolean, trace: TraceBase): AtomicBoolean = AtomicBoolean(initial, trace)
+
+public actual fun atomic(initial: Boolean): AtomicBoolean = atomic(initial, None)
 
 // ==================================== AtomicRef ====================================
 

--- a/atomicfu/src/nativeMain/kotlin/kotlinx/atomicfu/AtomicFU.kt
+++ b/atomicfu/src/nativeMain/kotlin/kotlinx/atomicfu/AtomicFU.kt
@@ -12,12 +12,16 @@ import kotlin.native.concurrent.FreezableAtomicReference as KAtomicRef
 import kotlin.native.concurrent.isFrozen
 import kotlin.native.concurrent.freeze
 import kotlin.reflect.KProperty
-import kotlin.reflect.KProperty0
+import kotlinx.atomicfu.TraceBase.None
 
 public actual fun <T> atomic(initial: T, trace: TraceBase): AtomicRef<T> = AtomicRef<T>(KAtomicRef(initial))
+public actual fun <T> atomic(initial: T): AtomicRef<T> = atomic(initial, None)
 public actual fun atomic(initial: Int, trace: TraceBase): AtomicInt = AtomicInt(KAtomicInt(initial))
+public actual fun atomic(initial: Int): AtomicInt = atomic(initial, None)
 public actual fun atomic(initial: Long, trace: TraceBase): AtomicLong = AtomicLong(KAtomicLong(initial))
+public actual fun atomic(initial: Long): AtomicLong = atomic(initial, None)
 public actual fun atomic(initial: Boolean, trace: TraceBase): AtomicBoolean = AtomicBoolean(KAtomicInt(if (initial) 1 else 0))
+public actual fun atomic(initial: Boolean): AtomicBoolean = atomic(initial, None)
 
 // ==================================== AtomicRef ====================================
 


### PR DESCRIPTION
The `Trace` parameter with a default value, added to atomic factory functions, broke binary compatibility in`0.15.0` 

For now, the fix is to return old declarations of atomic factory functions with one parameter.