### PR TITLE
Fixed running excluded tests in Idea

### DIFF
--- a/atomicfu/build.gradle
+++ b/atomicfu/build.gradle
@@ -252,12 +252,14 @@ task transformedTestFU_6(type: Test, dependsOn: [checkJdk16, transformFU]) {
     classpath = configurations.jvmTestRuntimeClasspath + project.files(classesPostTransformFU)
     testClassesDirs = project.files(classesPostTransformFU)
     exclude '**/*LFTest.*', '**/TraceToStringTest.*'
+    filter { setFailOnNoMatchingTests(false) } // to run excluded tests in Idea
 }
 
 task transformedTestFU_current(type: Test, dependsOn: transformFU) {
     classpath = files(configurations.jvmTestRuntimeClasspath, classesPostTransformFU)
     testClassesDirs = project.files(classesPostTransformFU)
     exclude '**/*LFTest.*', '**/TraceToStringTest.*'
+    filter { setFailOnNoMatchingTests(false) }
 }
 
 task transformedTestBOTH_6(type: Test, dependsOn: [checkJdk16, transformBOTH]) {
@@ -265,18 +267,21 @@ task transformedTestBOTH_6(type: Test, dependsOn: [checkJdk16, transformBOTH]) {
     classpath = files(configurations.jvmTestRuntimeClasspath, classesPostTransformBOTH)
     testClassesDirs = project.files(classesPostTransformBOTH)
     exclude '**/*LFTest.*', '**/TraceToStringTest.*', '**/TopLevelGeneratedDeclarationsReflectionTest.*', '**/SyntheticFUFieldsTest.*'
+    filter { setFailOnNoMatchingTests(false) }
 }
 
 task transformedTestBOTH_current(type: Test, dependsOn: transformBOTH) {
     classpath = files(configurations.jvmTestRuntimeClasspath, classesPostTransformBOTH)
     testClassesDirs = project.files(classesPostTransformBOTH)
     exclude '**/*LFTest.*', '**/TraceToStringTest.*', '**/TopLevelGeneratedDeclarationsReflectionTest.*', '**/SyntheticFUFieldsTest.*'
+    filter { setFailOnNoMatchingTests(false) }
 }
 
 task transformedTestVH(type: Test, dependsOn: transformVH) {
     classpath = files(configurations.jvmTestRuntimeClasspath, classesPostTransformVH)
     testClassesDirs = project.files(classesPostTransformVH)
     exclude '**/*LFTest.*', '**/TraceToStringTest.*', '**/TopLevelGeneratedDeclarationsReflectionTest.*', '**/SyntheticFUFieldsTest.*'
+    filter { setFailOnNoMatchingTests(false) }
 }
 
 transformedTestVH.onlyIf {


### PR DESCRIPTION
There was a problem with running tests excluded in `transformedTest*` tasks in Idea.
The following error was thrown:
```
No tests found for given includes: [**/*LFTest.*](exclude rules) [kotlinx.atomicfu.test.LockFreeQueueLFTest](filter.includeTestsMatching)
```
while these tests were executed correctly in the terminal.

Seems that Idea sets the property `failOnNoMatchingTests` to true in it's init script. 
Setting this property to false in gradle has priority over the Idea settings and solves the problem.