### PR TITLE
Update all split LVT instead of only one record

### DIFF
--- a/atomicfu-transformer/src/main/kotlin/kotlinx/atomicfu/transformer/AtomicFUTransformer.kt
+++ b/atomicfu-transformer/src/main/kotlin/kotlinx/atomicfu/transformer/AtomicFUTransformer.kt
@@ -13,6 +13,8 @@ import org.objectweb.asm.Type.*
 import org.objectweb.asm.commons.*
 import org.objectweb.asm.commons.InstructionAdapter.*
 import org.objectweb.asm.tree.*
+import org.objectweb.asm.util.Textifier
+import org.objectweb.asm.util.TraceMethodVisitor
 import java.io.*
 import java.net.*
 import java.util.*
@@ -703,6 +705,19 @@ class AtomicFUTransformer(
             super.visitMethodInsn(opcode, owner, name, desc, itf)
         }
 
+        internal val MethodNode?.nodeText: String
+            get() {
+                if (this == null) {
+                    return "Not generated"
+                }
+                val textifier = Textifier()
+                accept(TraceMethodVisitor(textifier))
+                val sw = StringWriter()
+                textifier.print(PrintWriter(sw))
+                sw.flush()
+                return name + " " + desc + ":\n" + sw.buffer.toString()
+            }
+
         override fun visitEnd() {
             // transform instructions list
             var hasErrors = false
@@ -1014,15 +1029,17 @@ class AtomicFUTransformer(
                     val lv = localVar(v, operation)
                     if (f.isStatic) instructions.remove(operation) // remove astore operation
                     if (lv != null) {
-                        // Stored to a local variable with an entry in LVT (typically because of inline function)
-                        if (lv.desc != f.fieldType.descriptor && !onArrayElement)
-                            abort("field $f was stored to a local variable #$v \"${lv.name}\" with unexpected type: ${lv.desc}")
-                        // correct local variable descriptor
-                        lv.desc = f.ownerType.descriptor
-                        lv.signature = null
-                        // process all loads of this variable in the corresponding local variable range
-                        forVarLoads(v, lv.start, lv.end) { otherLd ->
-                            fixupLoad(f, ld, otherLd, arrayElementInfo)
+                        for (lvn in localVariables.filter { it.index == lv.index && it.name == lv.name && it.desc == lv.desc }) {
+                            // Stored to a local variable with an entry in LVT (typically because of inline function)
+                            if (lvn.desc != f.fieldType.descriptor && !onArrayElement)
+                                abort("field $f was stored to a local variable #$v \"${lv.name}\" with unexpected type: ${lv.desc}")
+                            // correct local variable descriptor
+                            lvn.desc = f.ownerType.descriptor
+                            lvn.signature = null
+                            // process all loads of this variable in the corresponding local variable range
+                            forVarLoads(v, lvn.start, lvn.end) { otherLd ->
+                                fixupLoad(f, ld, otherLd, arrayElementInfo)
+                            }
                         }
                     } else {
                         // Spilled temporarily to a local variable w/o an entry in LVT -> fixup only one load

--- a/atomicfu/src/commonTest/kotlin/bytecode_test/SplitLvt.kt
+++ b/atomicfu/src/commonTest/kotlin/bytecode_test/SplitLvt.kt
@@ -1,0 +1,22 @@
+package bytecode_test
+
+import kotlinx.atomicfu.*
+import kotlin.coroutines.intrinsics.*
+
+class SplitLvt {
+    private val state = atomic(0)
+    private val a = 77
+    suspend fun foo() {
+        val a = suspendBar()
+    }
+    private inline fun AtomicInt.extensionFun() {
+        if (a == 77) throw IllegalStateException("AAAAAAAAAAAA")
+        value
+    }
+    private suspend inline fun suspendBar() {
+        state.extensionFun()
+        suspendCoroutineUninterceptedOrReturn<Any?> { ucont ->
+            COROUTINE_SUSPENDED
+        }
+    }
+}

--- a/atomicfu/src/jvmTest/kotlin/kotlinx/atomicfu/test/AtomicfuBytecodeTest.kt
+++ b/atomicfu/src/jvmTest/kotlin/kotlinx/atomicfu/test/AtomicfuBytecodeTest.kt
@@ -40,6 +40,12 @@ class AtomicfuBytecodeTest {
     @Test
     fun testDelegatedPropertiesBytecode() = checkBytecode(DelegatedProperties::class.java, listOf(KOTLIN_REFLECTION))
 
+    /**
+     * Test [SplitLvt]
+     */
+    @Test
+    fun testSplitLvt() = checkBytecode(SplitLvt::class.java, listOf(KOTLINX_ATOMICFU))
+
     private fun checkBytecode(javaClass: Class<*>, strings: List<String>) {
         val resourceName = javaClass.name.replace('.', '/') + ".class"
         val bytes = javaClass.classLoader.getResourceAsStream(resourceName)!!.use { it.readBytes() }


### PR DESCRIPTION
The compiler splits LVT in coroutines and thus we need to update all the
split records.
 #KT-47749