### PR TITLE
Correct artifact name for instructions on use within common sourceset.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ See [gradle.properties](gradle.properties) in AtomicFU project for its `kotlin_v
 
 ### Common
 
-If you write a common code that should get compiled or different platforms, add `org.jetbrains.kotlinx:atomicfu-common`
+If you write a common code that should get compiled or different platforms, add `org.jetbrains.kotlinx:atomicfu`
 to your common code dependencies or apply `kotlinx-atomicfu` plugin that adds this dependency automatically:
 
 ```groovy


### PR DESCRIPTION
It looks like the artifact name specified in the `README` under [the section](https://github.com/Kotlin/kotlinx.atomicfu#common) on how to include in `common` sourcesets is incorrect, has somewhat recently changed, or something failed to properly publish to Maven Central.

When I attempt to include `org.jetbrains.kotlinx:atomicfu-common:0.16.3` as a dependency in common code, resolution fails - but when I include `org.jetbrains.kotlinx:atomicfu:0.16.3`, resolution succeeds.