### PR TITLE
Atomicfu Js/Ir compiler plugin supported in the gradle plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ dependencies {
 
 ## IR transformation for Kotlin/JS
 
-There is a new option to turn on IR transformation for Kotlin/Js backend.
+There is a new option to turn on IR transformation for Kotlin/JS backend.
 You can add `kotlinx.atomicfu.enableIrTransformation=true` to your `gradle.properties` file in order to enable it.
 
 Here is how transformation is performed for different [JS compiler modes](https://kotlinlang.org/docs/js-ir-compiler.html) with this option enabled:

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ apply plugin: 'kotlinx-atomicfu'
 
 ### JS 
 
-Configure add apply plugin just like for [JVM](#jvm). 
+Configure add apply plugin just like for [JVM](#jvm).
 
 ### Native
 
@@ -149,16 +149,45 @@ dependencies {
 }
 ```
 
-### Additional configuration
+## Additional configuration
 
-There are the following additional parameters (with their defaults):
+To set configuration options you should create `atomicfu` section in a `build.gradle` file, 
+like this:
+```groovy
+atomicfu {
+  dependenciesVersion = '0.17.1'
+}
+```
 
+### JVM transformation options
+
+To turn off transformation for Kotlin/JVM set option `transformJvm` to `false`.
+
+Configuration option `jvmVariant` defines the Java class that replaces atomics during bytecode transformation.
+Here are the valid options:
+- `FU` – atomics are replaced with [AtomicXxxFieldUpdater](https://docs.oracle.com/javase/10/docs/api/java/util/concurrent/atomic/AtomicIntegerFieldUpdater.html).
+- `VH` – atomics are replaced with [VarHandle](https://docs.oracle.com/javase/9/docs/api/java/lang/invoke/VarHandle.html), 
+  this option is supported for JDK 9+.
+- `BOTH` – [multi-release jar file](https://openjdk.java.net/jeps/238) will be created with both `AtomicXxxFieldUpdater` for JDK <= 8 and `VarHandle` for JDK 9+.
+
+### JS transformation options
+
+To turn off transformation for Kotlin/JS set option `transformJs` to `false`.
+
+Configuration option `jsVariant` defines how transformation is performed on Kotlin/JS.
+Here are the valid options:
+- `JS` – JavaScript transformer implemented in the library is applied to the compiled `*.js` files.
+- `IR` – may be set if [Kotlin/JS IR backend](https://kotlinlang.org/docs/js-ir-compiler.html) is used for compilation, 
+  then `IR` generated from the Kotlin source code is transformed by the `kotlinx-atomicfu` compiler plugin.
+
+Here are all available configuration options (with their defaults):
 ```groovy
 atomicfu {
   dependenciesVersion = '0.17.1' // set to null to turn-off auto dependencies
   transformJvm = true // set to false to turn off JVM transformation
   transformJs = true // set to false to turn off JS transformation
-  variant = "FU" // JVM transformation variant: FU,VH, or BOTH 
+  jvmVariant = "FU" // JVM transformation variant: FU,VH, or BOTH 
+  jsVariant = "JS" // JS transformation variant: JS or IR
   verbose = false // set to true to be more verbose  
 }
 ```
@@ -236,22 +265,6 @@ which is then transformed to a regular `classes` directory to be used later by t
 ## Additional features
 
 AtomicFU provides some additional features that you can optionally use.
-
-### VarHandles with Java 9
-
-AtomicFU can produce code that uses Java 9 
-[VarHandle](https://docs.oracle.com/javase/9/docs/api/java/lang/invoke/VarHandle.html)
-instead of `AtomicXxxFieldUpdater`. Configure transformation `variant` in Gradle build file:
- 
-```groovy
-atomicfu {
-    variant = "VH"
-}
-``` 
- 
-It can also create [JEP 238](https://openjdk.java.net/jeps/238) multi-release jar file with both
-`AtomicXxxFieldUpdater` for JDK<=8 and `VarHandle` for for JDK9+ if you 
-set `variant` to `"BOTH"`.
 
 ### Arrays of atomic values
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,17 @@ dependencies {
 }
 ```
 
+## IR transformation for Kotlin/JS
+
+There is a new option to turn on IR transformation for Kotlin/Js backend.
+You should add `kotlinx.atomicfu.enableIrTransformation=true` to your `gradle.properties` file.
+
+Here is how transformation is performed for different [JS compiler modes](https://kotlinlang.org/docs/js-ir-compiler.html) with this option enabled:
+
+- `kotlin.js.compiler=legacy`: JavaScript transformer from the library is applied to the final compiled *.js files.
+- `kotlin.js.compiler=ir`: compiler plugin transformations are appiled to the generated IR.
+- `kotlin.js.compiler=both`: compiler plugin transformations are appiled to all compilations of IR targets, while compilations of legacy targets are transformed by the library.
+
 ## Additional configuration
 
 To set configuration options you should create `atomicfu` section in a `build.gradle` file, 
@@ -174,18 +185,11 @@ Here are the valid options:
 
 To turn off transformation for Kotlin/JS set option `transformJs` to `false`.
 
-Configuration option `jsVariant` defines how transformation is performed on Kotlin/JS.
-Here are the valid options:
-- `JS` – JavaScript transformer implemented in the library is applied to the compiled `*.js` files.
-- `IR` – may be set if [Kotlin/JS IR backend](https://kotlinlang.org/docs/js-ir-compiler.html) is used for compilation, 
-  then `IR` generated from the Kotlin source code is transformed by the `kotlinx-atomicfu` compiler plugin.
-
 Here are all available configuration options (with their defaults):
 ```groovy
 atomicfu {
   dependenciesVersion = '0.17.1' // set to null to turn-off auto dependencies
   transformJvm = true // set to false to turn off JVM transformation
-  transformJs = true // set to false to turn off JS transformation
   jvmVariant = "FU" // JVM transformation variant: FU,VH, or BOTH 
   jsVariant = "JS" // JS transformation variant: JS or IR
   verbose = false // set to true to be more verbose  

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ dependencies {
 ## IR transformation for Kotlin/JS
 
 There is a new option to turn on IR transformation for Kotlin/Js backend.
-You should add `kotlinx.atomicfu.enableIrTransformation=true` to your `gradle.properties` file.
+You can add `kotlinx.atomicfu.enableIrTransformation=true` to your `gradle.properties` file in order to enable it.
 
 Here is how transformation is performed for different [JS compiler modes](https://kotlinlang.org/docs/js-ir-compiler.html) with this option enabled:
 

--- a/atomicfu-gradle-plugin/build.gradle
+++ b/atomicfu-gradle-plugin/build.gradle
@@ -25,6 +25,8 @@ dependencies {
     compile 'org.jetbrains.kotlin:kotlin-stdlib'
 
     compileOnly "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    // atomicfu compiler plugin dependency will be loaded to kotlinCompilerPluginClasspath
+    implementation "org.jetbrains.kotlin:atomicfu:$kotlin_version"
 
     testCompile gradleTestKit()
     testCompile 'org.jetbrains.kotlin:kotlin-test'

--- a/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
+++ b/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
@@ -27,13 +27,16 @@ private const val ORIGINAL_DIR_NAME = "originalClassesDir"
 private const val COMPILE_ONLY_CONFIGURATION = "compileOnly"
 private const val IMPLEMENTATION_CONFIGURATION = "implementation"
 private const val TEST_IMPLEMENTATION_CONFIGURATION = "testImplementation"
+private const val ENABLE_IR_TRANSFORMATION = "kotlinx.atomicfu.enableIrTransformation"
 
 open class AtomicFUGradlePlugin : Plugin<Project> {
     override fun apply(project: Project) = project.run {
         val pluginVersion = rootProject.buildscript.configurations.findByName("classpath")
             ?.allDependencies?.find { it.name == "atomicfu-gradle-plugin" }?.version
         extensions.add(EXTENSION_NAME, AtomicFUPluginExtension(pluginVersion))
-        plugins.apply(AtomicfuKotlinGradleSubplugin::class.java)
+        if (rootProject.findProperty(ENABLE_IR_TRANSFORMATION).toString().toBoolean()) {
+            plugins.apply(AtomicfuKotlinGradleSubplugin::class.java)
+        }
         configureDependencies()
         configureTasks()
     }
@@ -421,7 +424,6 @@ class AtomicFUPluginExtension(pluginVersion: String?) {
     var dependenciesVersion = pluginVersion
     var transformJvm = true
     var transformJs = true
-    var jsVariant: String = "JS"
     var jvmVariant: String = "FU"
     var verbose: Boolean = false
 }

--- a/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
+++ b/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
@@ -33,10 +33,7 @@ open class AtomicFUGradlePlugin : Plugin<Project> {
         val pluginVersion = rootProject.buildscript.configurations.findByName("classpath")
             ?.allDependencies?.find { it.name == "atomicfu-gradle-plugin" }?.version
         extensions.add(EXTENSION_NAME, AtomicFUPluginExtension(pluginVersion))
-        if (config.transformJs && config.jsVariant == "IR") {
-            // apply the compiler plugin, if IR transformation should be applied to KotlinJsIrTarget compilations
-            plugins.apply(AtomicfuKotlinGradleSubplugin::class.java)
-        }
+        plugins.apply(AtomicfuKotlinGradleSubplugin::class.java)
         configureDependencies()
         configureTasks()
     }
@@ -87,7 +84,7 @@ private fun Project.configureTasks() {
 }
 
 private fun Project.needsJsIrTransformation(target: KotlinTarget): Boolean =
-    config.transformJs && config.jsVariant == "IR" && target.isJsIrTarget()
+    config.transformJs && target.isJsIrTarget()
 
 private fun KotlinTarget.isJsIrTarget() = (this is KotlinJsTarget && this.irTarget != null) || this is KotlinJsIrTarget
 
@@ -210,7 +207,9 @@ private fun Project.configureTransformationForTarget(target: KotlinTarget) {
             }
             KotlinPlatformType.js -> {
                 // skip when js transformation is not needed or when IR is transformed
-                if (!config.transformJs || (needsJsIrTransformation(target))) return@compilations
+                if (!config.transformJs || (needsJsIrTransformation(target))) {
+                    return@compilations
+                }
                 project.createJsTransformTask(compilation).configureJsTask(
                     compilation.compileAllTaskName,
                     transformedClassesDir,

--- a/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
+++ b/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
@@ -34,7 +34,7 @@ open class AtomicFUGradlePlugin : Plugin<Project> {
         val pluginVersion = rootProject.buildscript.configurations.findByName("classpath")
             ?.allDependencies?.find { it.name == "atomicfu-gradle-plugin" }?.version
         extensions.add(EXTENSION_NAME, AtomicFUPluginExtension(pluginVersion))
-        if (rootProject.findProperty(ENABLE_IR_TRANSFORMATION).toString().toBoolean()) {
+        if (rootProject.getBooleanProperty(ENABLE_IR_TRANSFORMATION)) {
             plugins.apply(AtomicfuKotlinGradleSubplugin::class.java)
         }
         configureDependencies()
@@ -84,6 +84,15 @@ private fun Project.configureTasks() {
     withPluginWhenEvaluated("kotlin-multiplatform") {
         configureMultiplatformTransformation()
     }
+}
+
+private fun Project.getBooleanProperty(name: String) =
+    rootProject.findProperty(name)?.toString()?.toBooleanStrict() ?: false
+
+private fun String.toBooleanStrict(): Boolean = when (this) {
+    "true" -> true
+    "false" -> false
+    else -> throw IllegalArgumentException("The string doesn't represent a boolean value: $this")
 }
 
 private fun Project.needsJsIrTransformation(target: KotlinTarget): Boolean =
@@ -264,7 +273,7 @@ fun Project.sourceSetsByCompilation(): Map<KotlinSourceSet, List<KotlinCompilati
 }
 
 fun Project.configureMultiplatformPluginDependencies(version: String) {
-    if (rootProject.findProperty("kotlin.mpp.enableGranularSourceSetsMetadata").toString().toBoolean()) {
+    if (rootProject.getBooleanProperty("kotlin.mpp.enableGranularSourceSetsMetadata")) {
         addCompilerPluginDependency()
         val mainConfigurationName = project.extensions.getByType(KotlinMultiplatformExtension::class.java).sourceSets
                 .getByName(KotlinSourceSet.COMMON_MAIN_SOURCE_SET_NAME)

--- a/atomicfu-maven-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/TransformMojo.kt
+++ b/atomicfu-maven-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/TransformMojo.kt
@@ -17,7 +17,7 @@
 package kotlinx.atomicfu.plugin
 
 import kotlinx.atomicfu.transformer.AtomicFUTransformer
-import kotlinx.atomicfu.transformer.Variant
+import kotlinx.atomicfu.transformer.JvmVariant
 import org.apache.maven.plugin.AbstractMojo
 import org.apache.maven.plugins.annotations.LifecyclePhase
 import org.apache.maven.plugins.annotations.Mojo
@@ -50,8 +50,8 @@ class TransformMojo : AbstractMojo() {
     /**
      * Transformation variant: "FU", "VH", or "BOTH".
      */
-    @Parameter(defaultValue = "FU", property = "variant", required = true)
-    lateinit var variant: Variant
+    @Parameter(defaultValue = "FU", property = "jvmVariant", required = true)
+    lateinit var jvmVariant: JvmVariant
 
     /**
      * Verbose debug info.
@@ -60,7 +60,7 @@ class TransformMojo : AbstractMojo() {
     var verbose: Boolean = false
 
     override fun execute() {
-        val t = AtomicFUTransformer(classpath, input, output, variant)
+        val t = AtomicFUTransformer(classpath, input, output, jvmVariant)
         t.verbose = verbose
         t.transform()
     }


### PR DESCRIPTION
- Added support of the compiler plugin transformation to the `AtomicfuGradlePlugin`.
- `atomicfu-gradle-plugin` test projects are ignored for a while. I'm going to create a PR with new test projects soon.
- Kotlin version is for now `1.7.0-dev-565`, [built](https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_KotlinDev_DeployMavenArtifacts/160253827?showRootCauses=false&expandBuildChangesSection=true) from the `1.6.20-M1-release branch`