### PR TITLE
Update README.md: Fix dependency for common module

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ to your common code dependencies or apply `kotlinx-atomicfu` plugin that adds th
 
 ```groovy
 dependencies {
-    compile "org.jetbrains.kotlinx:atomicfu-common:$atomicfu_version"
+    compile "org.jetbrains.kotlinx:atomicfu:$atomicfu_version"
 }
 ```
 


### PR DESCRIPTION
According to the official's [document](https://kotlinlang.org/docs/migrating-multiplatform-project-to-14.html#follow-the-default-libraries-layout), platform suffix for MPP library name is not recommended, also it doesn't exist in the maven central.