### PR TITLE
Update kotlinx.metadata to 0.5.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ kotlin_version=1.7.0
 asm_version=9.3
 slf4j_version=1.8.0-alpha2
 junit_version=4.12
-kotlinx_metadata_version=0.4.2
+kotlinx_metadata_version=0.5.0
 
 maven_version=3.5.3
 


### PR DESCRIPTION
We need new metadata to update `languageVersion` to 1.8

Revealed by [failing tests](https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_KotlinDev_atomicfu/212226612?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true&expandBuildProblemsSection=true) in `kotlinx.train-1.8.0` branch.