### PR TITLE
Comply with new compiler restriction on actual declaration annotations

### DIFF
--- a/atomicfu/src/jsMain/kotlin/kotlinx/atomicfu/AtomicFU.kt
+++ b/atomicfu/src/jsMain/kotlin/kotlinx/atomicfu/AtomicFU.kt
@@ -2,12 +2,19 @@
  * Copyright 2017-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-@file:Suppress("NOTHING_TO_INLINE", "RedundantVisibilityModifier", "CanBePrimaryConstructorProperty")
+@file:Suppress(
+    "NOTHING_TO_INLINE",
+    "RedundantVisibilityModifier",
+    "CanBePrimaryConstructorProperty",
+    "INVISIBLE_REFERENCE",
+    "INVISIBLE_MEMBER"
+)
 
 package kotlinx.atomicfu
 
-import kotlin.reflect.KProperty
 import kotlinx.atomicfu.TraceBase.None
+import kotlin.internal.InlineOnly
+import kotlin.reflect.KProperty
 
 @JsName(ATOMIC_REF_FACTORY)
 public actual fun <T> atomic(initial: T, trace: TraceBase): AtomicRef<T> = AtomicRef<T>(initial)
@@ -39,8 +46,10 @@ public actual class AtomicRef<T> internal constructor(value: T) {
     @JsName(ATOMIC_VALUE)
     public actual var value: T = value
 
+    @InlineOnly
     public actual inline operator fun getValue(thisRef: Any?, property: KProperty<*>): T = value
 
+    @InlineOnly
     public actual inline operator fun setValue(thisRef: Any?, property: KProperty<*>, value: T) { this.value = value }
 
     public actual inline fun lazySet(value: T) { this.value = value }
@@ -68,8 +77,10 @@ public actual class AtomicBoolean internal constructor(value: Boolean) {
     @JsName(ATOMIC_VALUE)
     public actual var value: Boolean = value
 
+    @InlineOnly
     public actual inline operator fun getValue(thisRef: Any?, property: KProperty<*>): Boolean = value
 
+    @InlineOnly
     public actual inline operator fun setValue(thisRef: Any?, property: KProperty<*>, value: Boolean) { this.value = value }
 
     public actual inline fun lazySet(value: Boolean) {
@@ -99,8 +110,10 @@ public actual class AtomicInt internal constructor(value: Int) {
     @JsName(ATOMIC_VALUE)
     public actual var value: Int = value
 
+    @InlineOnly
     actual inline operator fun getValue(thisRef: Any?, property: KProperty<*>): Int = value
 
+    @InlineOnly
     public actual inline operator fun setValue(thisRef: Any?, property: KProperty<*>, value: Int) { this.value = value }
 
     public actual inline fun lazySet(value: Int) { this.value = value }
@@ -157,8 +170,10 @@ public actual class AtomicLong internal constructor(value: Long) {
     @JsName(ATOMIC_VALUE)
     public actual var value: Long = value
 
+    @InlineOnly
     public actual inline operator fun getValue(thisRef: Any?, property: KProperty<*>): Long = value
 
+    @InlineOnly
     public actual inline operator fun setValue(thisRef: Any?, property: KProperty<*>, value: Long) { this.value = value }
 
     public actual inline fun lazySet(value: Long) { this.value = value }

--- a/atomicfu/src/jvmMain/kotlin/kotlinx/atomicfu/AtomicFU.kt
+++ b/atomicfu/src/jvmMain/kotlin/kotlinx/atomicfu/AtomicFU.kt
@@ -3,7 +3,7 @@
  */
 
 @file:JvmName("AtomicFU")
-@file:Suppress("NOTHING_TO_INLINE", "RedundantVisibilityModifier")
+@file:Suppress("NOTHING_TO_INLINE", "RedundantVisibilityModifier", "INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
 
 package kotlinx.atomicfu
 
@@ -12,6 +12,7 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater
 import kotlin.reflect.KProperty
 import kotlinx.atomicfu.TraceBase.None
+import kotlin.internal.InlineOnly
 
 /**
  * Creates atomic reference with a given [initial] value.
@@ -84,8 +85,10 @@ public actual class AtomicRef<T> internal constructor(value: T, val trace: Trace
             if (trace !== None) trace { "set($value)" }
         }
 
+    @InlineOnly
     public actual inline operator fun getValue(thisRef: Any?, property: KProperty<*>): T = value
 
+    @InlineOnly
     public actual inline operator fun setValue(thisRef: Any?, property: KProperty<*>, value: T) { this.value = value }
 
     /**
@@ -135,8 +138,10 @@ public actual class AtomicBoolean internal constructor(v: Boolean, val trace: Tr
     @Volatile
     private var _value: Int = if (v) 1 else 0
 
+    @InlineOnly
     public actual inline operator fun getValue(thisRef: Any?, property: KProperty<*>): Boolean = value
 
+    @InlineOnly
     public actual inline operator fun setValue(thisRef: Any?, property: KProperty<*>, value: Boolean) { this.value = value }
 
     /**
@@ -204,8 +209,10 @@ public actual class AtomicInt internal constructor(value: Int, val trace: TraceB
             if (trace !== None) trace { "set($value)" }
         }
 
+    @InlineOnly
     public actual inline operator fun getValue(thisRef: Any?, property: KProperty<*>): Int = value
 
+    @InlineOnly
     public actual inline operator fun setValue(thisRef: Any?, property: KProperty<*>, value: Int) { this.value = value }
 
     /**
@@ -327,8 +334,10 @@ public actual class AtomicLong internal constructor(value: Long, val trace: Trac
             if (trace !== None) trace { "set($value)" }
         }
 
+    @InlineOnly
     public actual inline operator fun getValue(thisRef: Any?, property: KProperty<*>): Long = value
 
+    @InlineOnly
     public actual inline operator fun setValue(thisRef: Any?, property: KProperty<*>, value: Long) { this.value = value }
 
     /**

--- a/atomicfu/src/nativeMain/kotlin/kotlinx/atomicfu/AtomicFU.kt
+++ b/atomicfu/src/nativeMain/kotlin/kotlinx/atomicfu/AtomicFU.kt
@@ -2,7 +2,13 @@
  * Copyright 2017-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-@file:Suppress("NOTHING_TO_INLINE", "RedundantVisibilityModifier", "CanBePrimaryConstructorProperty")
+@file:Suppress(
+    "NOTHING_TO_INLINE",
+    "RedundantVisibilityModifier",
+    "CanBePrimaryConstructorProperty",
+    "INVISIBLE_REFERENCE",
+    "INVISIBLE_MEMBER"
+)
 
 package kotlinx.atomicfu
 
@@ -13,6 +19,7 @@ import kotlin.native.concurrent.isFrozen
 import kotlin.native.concurrent.freeze
 import kotlin.reflect.KProperty
 import kotlinx.atomicfu.TraceBase.None
+import kotlin.internal.InlineOnly
 
 public actual fun <T> atomic(initial: T, trace: TraceBase): AtomicRef<T> = AtomicRef<T>(KAtomicRef(initial))
 public actual fun <T> atomic(initial: T): AtomicRef<T> = atomic(initial, None)
@@ -34,8 +41,10 @@ public actual value class AtomicRef<T> internal constructor(@PublishedApi intern
             a.value = value
         }
 
+    @InlineOnly
     public actual inline operator fun getValue(thisRef: Any?, property: KProperty<*>): T = value
 
+    @InlineOnly
     public actual inline operator fun setValue(thisRef: Any?, property: KProperty<*>, value: T) { this.value = value }
 
     public actual inline fun lazySet(value: T) {
@@ -100,8 +109,10 @@ public actual value class AtomicInt internal constructor(@PublishedApi internal 
         get() = a.value
         set(value) { a.value = value }
 
+    @InlineOnly
     actual inline operator fun getValue(thisRef: Any?, property: KProperty<*>): Int = value
 
+    @InlineOnly
     public actual inline operator fun setValue(thisRef: Any?, property: KProperty<*>, value: Int) { this.value = value }
 
     public actual inline fun lazySet(value: Int) { a.value = value }


### PR DESCRIPTION
In [KT-58551](https://youtrack.jetbrains.com/issue/KT-58551) we require all annotations from expect declaration to be present on actual.
This commit fixes violations on get/setValue methods, having `@InlineOnly` set only on `expect` declaration.