### PR TITLE
KT-78372 Disable Klibs cross compilation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ version=0.28.0-SNAPSHOT
 group=org.jetbrains.kotlinx
 
 kotlin.native.ignoreDisabledTargets=true
-
+kotlin.native.enableKlibsCrossCompilation=false
 kotlin.mpp.enableCInteropCommonization=true
 
 # Workaround for Bintray treating .sha512 files as artifacts


### PR DESCRIPTION
Since Kotlin 2.2.20 we’ve been planning to enable [Klibs cross compilation by default](https://youtrack.jetbrains.com/issue/KT-76421/Stabilize-klib-cross-compilation-on-different-platforms). For atomicfu we now need to explicitly disable cross compilation `kotlin.native.enableKlibsCrossCompilation=false`