### PR TITLE
Deprecation of apple x64 targets

### DIFF
--- a/atomicfu/build.gradle.kts
+++ b/atomicfu/build.gradle.kts
@@ -12,20 +12,16 @@ kotlin {
     jvmToolchain(8)
     
     // Tier 1
-    macosX64()
     macosArm64()
     iosSimulatorArm64()
-    iosX64()
 
     // Tier 2
     linuxX64()
     linuxArm64()
     watchosSimulatorArm64()
-    watchosX64()
     watchosArm32()
     watchosArm64()
     tvosSimulatorArm64()
-    tvosX64()
     tvosArm64()
     iosArm64()
 
@@ -36,9 +32,19 @@ kotlin {
     androidNativeX64()
     mingwX64()
     watchosDeviceArm64()
-    
+
+    // Deprecated
     @Suppress("DEPRECATION") //https://github.com/Kotlin/kotlinx-atomicfu/issues/207
     linuxArm32Hfp()
+
+    @Suppress("DEPRECATION")
+    iosX64()
+    @Suppress("DEPRECATION")
+    macosX64()
+    @Suppress("DEPRECATION")
+    tvosX64()
+    @Suppress("DEPRECATION")
+    watchosX64()
 
     // JS -- always
     js(IR) {


### PR DESCRIPTION
Kotlin is deprecating x64 family of apple targets, due to Apple also stopping the support for them.

See [KT-78660](https://youtrack.jetbrains.com/issue/KT-78660) for more details.