### PR TITLE
Remove Rhino dependency

### DIFF
--- a/atomicfu-transformer/build.gradle.kts
+++ b/atomicfu-transformer/build.gradle.kts
@@ -10,7 +10,6 @@ plugins {
 dependencies {
     api(libs.bundles.asm)
     api(libs.slf4j.api)
-    api(libs.mozilla.rhino)
     api(libs.kotlin.metadataJvm)
 
     compileOnly(libs.kotlin.stdlib)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,6 @@ junit = "4.12"
 maven = "3.5.3"
 maven-pluginTools = "3.5"
 node-gradle = "3.1.1"
-rhino = "1.7.10"
 gradle-plugin-publish = "1.2.1"
 gradle-develocity = "3.17.6"
 lincheck = "3.1.1"
@@ -47,9 +46,6 @@ jetbrains-lincheck = { group = "org.jetbrains.lincheck", name = "lincheck", vers
 maven-core = { group = "org.apache.maven", name = "maven-core", version.ref = "maven" }
 maven-pluginApi = { group = "org.apache.maven", name = "maven-plugin-api", version.ref = "maven" }
 maven-pluginAnnotations = { group = "org.apache.maven.plugin-tools", name = "maven-plugin-annotations", version.ref = "maven-pluginTools" }
-
-# Other dependencies
-mozilla-rhino = { group = "org.mozilla", name = "rhino", version.ref = "rhino" }
 
 [bundles]
 asm = ["asm", "asm-commons", "asm-tree", "asm-util"]


### PR DESCRIPTION
While JS support was removed back in atomicfu 0.26.0 ([ref](https://github.com/Kotlin/kotlinx-atomicfu/releases/tag/0.26.0)), the atomicfu-transformer still includes (and exposes via `api`) a now-unused dependency on [mozilla-rhino](https://github.com/mozilla/rhino) to this day. Since this is also includes an outdated, vulnerable version, dependent projects receive a Dependabot warning. (The screenshot below pertains to atomicfu 0.28.0, but the same dependency is still included in 0.30.0-beta.)

<img width="1149" height="767" alt="Screenshot 2026-01-07 at 6 49 06" src="https://github.com/user-attachments/assets/936e7613-0244-4fb9-a2f1-9a4ba2169253" />

As I cannot find any further usages of Rhino APIs inside the transformer, there is no need to expose this dependency anymore. Remove it.

Resolves #567.