### PR TITLE
Add logic to handle changed `.kotlin_module` file name in test

### DIFF
--- a/integration-testing/build.gradle.kts
+++ b/integration-testing/build.gradle.kts
@@ -65,6 +65,9 @@ val mavenTest by tasks.registering(Test::class) {
     testClassesDirs = sourceSets["mavenTest"].output.classesDirs
     classpath = sourceSets["mavenTest"].runtimeClasspath
 
+    // the kotlin version used to build the library, which is set in root gradle.properties or overriden by the TC config
+    systemProperties["kotlin.version.integration"] = providers.gradleProperty("kotlin_version").orNull
+
     dependsOn(":atomicfu:publishToMavenLocal")
 
     outputs.upToDateWhen { false }

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/JvmProjectTest.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/JvmProjectTest.kt
@@ -55,14 +55,25 @@ class JvmProjectTest {
 
         jvmSample.build().apply {
             assertTrue { buildClassesAtomicfuDir.exists() }
-            assertEquals(
+            val expectedFiles = if (kotlinVersion.startsWith("2.4")) {
+                """
+                build/classes/atomicfu/main/IntArithmetic.class
+                build/classes/atomicfu/main/META-INF/kotlinx.atomicfu.examples_jvm-sample.kotlin_module
+                build/classes/atomicfu/main/MainKt.class
+                build/classes/atomicfu/test/ArithmeticTest.class
+                build/classes/atomicfu/test/META-INF/kotlinx.atomicfu.examples_jvm-sample_test.kotlin_module
+                """.trimIndent()
+            } else {
                 """
                 build/classes/atomicfu/main/IntArithmetic.class
                 build/classes/atomicfu/main/META-INF/jvm-sample.kotlin_module
                 build/classes/atomicfu/main/MainKt.class
                 build/classes/atomicfu/test/ArithmeticTest.class
                 build/classes/atomicfu/test/META-INF/jvm-sample_test.kotlin_module
-                """.trimIndent(),
+                """.trimIndent()
+            }
+            assertEquals(
+                expectedFiles,
                 buildClassesAtomicFuDirFiles()
             )
         }

--- a/integration-testing/src/mavenTest/kotlin/MavenPublicationMetaInfValidator.kt
+++ b/integration-testing/src/mavenTest/kotlin/MavenPublicationMetaInfValidator.kt
@@ -7,16 +7,30 @@ import kotlin.test.Test
 import kotlin.test.fail
 
 class MavenPublicationMetaInfValidator {
+
+    private val kotlinVersion = System.getProperty("kotlin.version.integration")
+
     @Test
     fun testMetaInfContents() {
         val clazz = Class.forName("kotlinx.atomicfu.AtomicFU")
-        JarFile(clazz.protectionDomain.codeSource.location.file).compareMetaInfContents(
-            setOf(
-                "MANIFEST.MF",
-                "atomicfu.kotlin_module",
-                "versions/9/module-info.class"
+        if (kotlinVersion.startsWith("2.4")) {
+            // See KT-69701 Gradle: module name is passed inconsistently to different types of compilations
+            JarFile(clazz.protectionDomain.codeSource.location.file).compareMetaInfContents(
+                setOf(
+                    "MANIFEST.MF",
+                    "org.jetbrains.kotlinx_atomicfu.kotlin_module",
+                    "versions/9/module-info.class"
+                )
             )
-        )
+        } else {
+            JarFile(clazz.protectionDomain.codeSource.location.file).compareMetaInfContents(
+                setOf(
+                    "MANIFEST.MF",
+                    "atomicfu.kotlin_module",
+                    "versions/9/module-info.class"
+                )
+            )
+        }
     }
 
     private fun JarFile.compareMetaInfContents(expected: Set<String>) {


### PR DESCRIPTION
Due to KT-69701, Kotlin 2.4.0 changes `.kotlin_module` file name to align with other platforms. This change requires adjusting the test logic.