### PR TITLE
Temporarily disable -Werror in buildSrc compilation

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,5 +8,6 @@ dependencies {
 }
 
 kotlin {
-    compilerOptions.allWarningsAsErrors = true
+    // KMP KGP has an opt-in type in the accessors. Enable -Werror after bumping Gradle to 9+ https://github.com/gradle/gradle/issues/32019
+    // compilerOptions.allWarningsAsErrors = true
 }


### PR DESCRIPTION
SwiftPM import extension generates an accessor that uses an opt-in type which emitted warnings prior to Gradle 9

See https://github.com/gradle/gradle/issues/32019

^KT-62237