### PR TITLE
Do not use deprecated `js(compiler: KotlinJsCompilerType, ...)` DSL

### DIFF
--- a/atomicfu/build.gradle.kts
+++ b/atomicfu/build.gradle.kts
@@ -46,7 +46,7 @@ kotlin {
     watchosX64()
 
     // JS -- always
-    js(IR) {
+    js {
         outputModuleName = "kotlinx-atomicfu"
         // TODO: commented out because browser tests do not work on TeamCity
         // browser()

--- a/integration-testing/examples/mpp-version-catalog/shared/build.gradle.kts
+++ b/integration-testing/examples/mpp-version-catalog/shared/build.gradle.kts
@@ -20,7 +20,7 @@ kotlin {
 
     jvm()
 
-    js(IR)
+    js()
 
     macosArm64()
     @Suppress("DEPRECATION", "DEPRECATION_ERROR")


### PR DESCRIPTION
`js(compiler: KotlinJsCompilerType, ...)` DSL overrides and `KotlinJsCompilerType` will be deprecated in Kotlin 2.4.0, see [KT-84753](https://youtrack.jetbrains.com/issue/KT-84753) Deprecate `KotlinJsCompilerType` and `KotlinProjectExtension` methods using it