### PR TITLE
Manually configure some cache-redirected repositories

### DIFF
--- a/build-settings-logic/settings.gradle.kts
+++ b/build-settings-logic/settings.gradle.kts
@@ -4,14 +4,23 @@ dependencyResolutionManagement {
 
     @Suppress("UnstableApiUsage")
     repositories {
-        mavenCentral()
-        gradlePluginPortal()
+        // mavenCentral(), cache-redirected
+        maven("https://cache-redirector.jetbrains.com/repo.maven.apache.org/maven2")
+        // gradlePluginPortal(), cache-redirected
+        maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2")
     }
 
     versionCatalogs {
         create("libs") {
             from(files("../gradle/libs.versions.toml"))
         }
+    }
+}
+
+pluginManagement {
+    repositories {
+        // gradlePluginPortal(), cache-redirected
+        maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2")
     }
 }
 

--- a/build-settings-logic/src/main/kotlin/atomicfu-dependency-resolution-management.settings.gradle.kts
+++ b/build-settings-logic/src/main/kotlin/atomicfu-dependency-resolution-management.settings.gradle.kts
@@ -38,8 +38,8 @@ dependencyResolutionManagement {
             logger.info("A custom Kotlin repository ${additionalRepositoryProperty.get()} was added")
         }
 
-        mavenCentral()
-
+        // mavenCentral(), cache-redirected
+        maven("https://cache-redirector.jetbrains.com/repo.maven.apache.org/maven2")
 
         // we have such a task https://youtrack.jetbrains.com/issue/KT-34732 to move these artifacts to the Maven repository,
         // but before that we need to have ivy for yarn and node dependencies

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,11 @@ rootProject.name = "kotlinx-atomicfu"
 
 pluginManagement {
     includeBuild("build-settings-logic")
+
+    repositories {
+        // gradlePluginPortal(), cache-redirected
+        maven("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2")
+    }
 }
 
 plugins {


### PR DESCRIPTION
Cache redirector plugin sets up majority of repositories, however, some may be used before it is applied.
This change "fixes" all such repositories.